### PR TITLE
Type change integration into CFG

### DIFF
--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -3248,6 +3248,7 @@ static expr_ret_package_t emit_binary_operation(basic_block_t* basic_block, gene
 	
 	three_addr_var_t* op1;
 	
+
 	//If this is temporary, we're fine. Otherwise emit one
 	if(left_hand_temp.assignee->is_temporary == TRUE){
 		op1 = left_hand_temp.assignee;

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -3275,13 +3275,13 @@ static expr_ret_package_t emit_binary_operation(basic_block_t* basic_block, gene
 	Token binary_operator = logical_or_expr->binary_operator;
 	//Store this binary operator
 	package.operator = binary_operator;
-
+	//Grab this out for convenience
 	three_addr_var_t* op2 = right_hand_temp.assignee;
 
-	//Emit a converting move instruction if we don't have a const assignment
-	if(right_hand_temp.assignee->type != right_hand_type && basic_block->exit_statement->CLASS != THREE_ADDR_CODE_ASSN_CONST_STMT){
+	//Emit a converting move instruction if we don't have a const assignment as the immediate previous statement
+	if(op2->type != right_hand_type && basic_block->exit_statement->CLASS != THREE_ADDR_CODE_ASSN_CONST_STMT){
 		//We'll need a converting move instruction here to deal with this
-		instruction_t* temp_assignment = emit_converting_move_instruction(emit_temp_var(right_hand_type), right_hand_temp.assignee);
+		instruction_t* temp_assignment = emit_converting_move_instruction(emit_temp_var(right_hand_type), op2);
 
 		add_statement(basic_block, temp_assignment);
 		//add_used_variable(basic_block, right_hand_temp.assignee);

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -3232,6 +3232,7 @@ static expr_ret_package_t emit_binary_operation(basic_block_t* basic_block, gene
 	//Otherwise we actually have a binary operation of some kind
 	//Grab a cursor
 	generic_ast_node_t* cursor = logical_or_expr->first_child;
+	generic_type_t* return_type = logical_or_expr->inferred_type;
 	
 	//Emit the binary expression on the left first
 	expr_ret_package_t left_hand_temp = emit_binary_operation(basic_block, cursor, is_branch_ending);
@@ -3242,13 +3243,14 @@ static expr_ret_package_t emit_binary_operation(basic_block_t* basic_block, gene
 	//	add %rax, %rbx is the same as saying %rbx = %rbx + %rax. So whatever RBX was it no longer is
 	
 	three_addr_var_t* op1;
+	three_addr_var_t* op2;
 	
 	//If this is temporary, we're fine. Otherwise emit one
 	if(left_hand_temp.assignee->is_temporary == TRUE){
 		op1 = left_hand_temp.assignee;
 	} else {
 		//emit the temp assignment
-		instruction_t* temp_assnment = emit_assignment_instruction(emit_temp_var(left_hand_temp.assignee->type), left_hand_temp.assignee);
+		instruction_t* temp_assnment = emit_assignment_instruction(emit_temp_var(return_type), left_hand_temp.assignee);
 		//Add it into here
 		add_statement(basic_block, temp_assnment);
 		
@@ -3265,6 +3267,23 @@ static expr_ret_package_t emit_binary_operation(basic_block_t* basic_block, gene
 	//Then grab the right hand temp
 	expr_ret_package_t right_hand_temp = emit_binary_operation(basic_block, cursor, is_branch_ending);
 
+	//If this is temporary, we're fine. Otherwise emit one
+	if(right_hand_temp.assignee->is_temporary == TRUE){
+		op2 = right_hand_temp.assignee;
+	} else {
+		//emit the temp assignment
+		instruction_t* temp_assnment = emit_assignment_instruction(emit_temp_var(return_type), right_hand_temp.assignee);
+		//Add it into here
+		add_statement(basic_block, temp_assnment);
+		
+		//We can mark that op1 was used
+		add_used_variable(basic_block, right_hand_temp.assignee);
+		
+		//Grab the assignee out
+		op2 = temp_assnment->assignee;
+	}
+
+
 	//Let's see what binary operator that we have
 	Token binary_operator = logical_or_expr->binary_operator;
 	//Store this binary operator
@@ -3274,7 +3293,7 @@ static expr_ret_package_t emit_binary_operation(basic_block_t* basic_block, gene
 	instruction_t* stmt;
 
 	//Emit the binary operator expression using our helper
-	stmt = emit_binary_operation_instruction(op1, op1, binary_operator, right_hand_temp.assignee);
+	stmt = emit_binary_operation_instruction(op1, op1, binary_operator, op2);
 
 	//Mark this with what we have
 	stmt->is_branch_ending = is_branch_ending;

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -3213,7 +3213,7 @@ static three_addr_var_t* emit_unary_expr_code(basic_block_t* basic_block, generi
  *
  */
 static expr_ret_package_t emit_binary_operation(basic_block_t* basic_block, generic_ast_node_t* logical_or_expr, u_int8_t is_branch_ending){
-		//The return package here
+	//The return package here
 	expr_ret_package_t package;
 	//Operator is blank by default
 	package.operator = BLANK;

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -3278,8 +3278,10 @@ static expr_ret_package_t emit_binary_operation(basic_block_t* basic_block, gene
 
 	three_addr_var_t* op2 = right_hand_temp.assignee;
 
-	if(right_hand_temp.assignee->type != right_hand_type){
-		instruction_t* temp_assignment = emit_assignment_instruction(emit_temp_var(right_hand_type), right_hand_temp.assignee);
+	//Emit a converting move instruction if we don't have a const assignment
+	if(right_hand_temp.assignee->type != right_hand_type && basic_block->exit_statement->CLASS != THREE_ADDR_CODE_ASSN_CONST_STMT){
+		//We'll need a converting move instruction here to deal with this
+		instruction_t* temp_assignment = emit_converting_move_instruction(emit_temp_var(right_hand_type), right_hand_temp.assignee);
 
 		add_statement(basic_block, temp_assignment);
 		//add_used_variable(basic_block, right_hand_temp.assignee);

--- a/oc/compiler/compiler.c
+++ b/oc/compiler/compiler.c
@@ -36,6 +36,7 @@ static void print_help(){
 	printf("-f <filename>: Required field. Specifies the .ol source file to be compiled\n");
 	printf("\n######################################## Optional Fields #########################################\n");
 	printf("-o <filename>: Specificy the output location. If none is given, out.ol will be used\n");
+	printf("-s: Show a summary at the end of compilation\n");
 	printf("-a: Generate an assembly code file with a .s extension\n");
 	printf("-d: Show all debug information printed. This includes compiler warnings, info statements\n");
 	printf("-t: Time execution of compiler. Can be used for performance testing\n");

--- a/oc/compiler/instruction/instruction.c
+++ b/oc/compiler/instruction/instruction.c
@@ -423,6 +423,44 @@ instruction_t* emit_push_instruction(three_addr_var_t* pushee){
 
 
 /**
+ * Emit a movzx(zero extend) instruction
+ */
+instruction_t* emit_movzx_instruction(three_addr_var_t* source, three_addr_var_t* destination){
+	//First we allocate it
+	instruction_t* instruction = calloc(1, sizeof(instruction_t));
+
+	//Set the instruction type
+	instruction->instruction_type = MOVZX;
+
+	//Set the source and destination
+	instruction->source_register = source;
+	instruction->destination_register = destination;
+
+	//And following that, we're all set
+	return instruction;
+}
+
+
+/**
+ * Emit a movsx(sign extend) instruction
+ */
+instruction_t* emit_movsx_instruction(three_addr_var_t* source, three_addr_var_t* destination){
+	//First we allocate it
+	instruction_t* instruction = calloc(1, sizeof(instruction_t));
+
+	//Set the instruction type
+	instruction->instruction_type = MOVSX;
+
+	//Set the source and destination
+	instruction->source_register = source;
+	instruction->destination_register = destination;
+
+	//And following that, we're all set
+	return instruction;
+}
+
+
+/**
  * Emit a pop instruction. We only have one kind of popping - quadwords - we don't
  * deal with getting granular when popping 
  */

--- a/oc/compiler/instruction/instruction.c
+++ b/oc/compiler/instruction/instruction.c
@@ -1532,7 +1532,7 @@ static void print_converting_move(instruction_t* instruction, variable_printing_
 	if(instruction->instruction_type == MOVZX){
 		printf("movzx ");
 	} else {
-		printf("movsx");
+		printf("movsx ");
 	}
 
 	//Now we'll print the source and destination

--- a/oc/compiler/instruction/instruction.c
+++ b/oc/compiler/instruction/instruction.c
@@ -2818,6 +2818,25 @@ instruction_t* emit_binary_operation_with_const_instruction(three_addr_var_t* as
 
 
 /**
+ * Emit a converting move statement. This is basically an assignee, except for the fact that we're explicitly marking that
+ * there will be a conversion(either sign extend or zero extend) that will take place here
+ */
+instruction_t* emit_converting_move_instruction(three_addr_var_t* assignee, three_addr_var_t* op1){
+	//First allocate it
+	instruction_t* stmt = calloc(1, sizeof(instruction_t));
+
+	//Let's now populate it with values
+	stmt->CLASS = THREE_ADDR_CODE_CONVERTING_ASSIGNMENT_STMT;
+	stmt->assignee = assignee;
+	stmt->op1 = op1;
+	//What function are we in
+	stmt->function = current_function;
+	//And that's it, we'll just leave our now
+	return stmt;
+}
+
+
+/**
  * Emit an assignment three address code statement. Once we're here, we expect that the caller has created and supplied the
  * appropriate variables
  */

--- a/oc/compiler/instruction/instruction.c
+++ b/oc/compiler/instruction/instruction.c
@@ -1125,6 +1125,13 @@ void print_three_addr_code_stmt(instruction_t* stmt){
 		printf(" <- ");
 		print_variable(stmt->op1, PRINTING_VAR_INLINE);
 		printf("\n");
+	//Emit a converting assignment statement that is used when we have type mismatches
+	} else if(stmt->CLASS == THREE_ADDR_CODE_CONVERTING_ASSIGNMENT_STMT){
+		//We'll print out the left and right ones here
+		print_variable(stmt->assignee, PRINTING_VAR_INLINE);
+		printf(" <-CONVERTING-- ");
+		print_variable(stmt->op1, PRINTING_VAR_INLINE);
+		printf("\n");
 	//Assigning a memory address to a variable
 	} else if (stmt->CLASS == THREE_ADDR_CODE_MEM_ADDR_ASSIGNMENT){
 		//We'll print out the left and right ones here
@@ -1514,6 +1521,26 @@ static void print_addressing_mode_expression(instruction_t* instruction, variabl
 		default:
 			break;
 	}
+}
+
+
+/**
+ * Print a movzx or movsx(converting move) instruction
+ */
+static void print_converting_move(instruction_t* instruction, variable_printing_mode_t mode){
+	//First we'll determine what to print
+	if(instruction->instruction_type == MOVZX){
+		printf("movzx ");
+	} else {
+		printf("movsx");
+	}
+
+	//Now we'll print the source and destination
+	print_variable(instruction->source_register, mode);
+	printf(", ");
+	print_variable(instruction->destination_register, mode);
+
+	printf("\n");
 }
 
 
@@ -2452,6 +2479,12 @@ void print_instruction(instruction_t* instruction, variable_printing_mode_t mode
 		case MOVQ:
 			//Invoke the helper
 			print_register_to_register_move(instruction, mode);
+			break;
+
+		//Handle a converting move
+		case MOVSX:
+		case MOVZX:
+			print_converting_move(instruction, mode);
 			break;
 
 		//Handle lea printing

--- a/oc/compiler/instruction/instruction.h
+++ b/oc/compiler/instruction/instruction.h
@@ -283,6 +283,8 @@ typedef enum{
 	THREE_ADDR_CODE_BIN_OP_WITH_CONST_STMT,
 	//Regular two address assignment
 	THREE_ADDR_CODE_ASSN_STMT,
+	//A converting assignment statement
+	THREE_ADDR_CODE_CONVERTING_ASSIGNMENT_STMT,
 	//Assigning a constant to a variable
 	THREE_ADDR_CODE_ASSN_CONST_STMT,
 	//A return statement

--- a/oc/compiler/instruction/instruction.h
+++ b/oc/compiler/instruction/instruction.h
@@ -627,6 +627,12 @@ instruction_t* emit_binary_operation_instruction(three_addr_var_t* assignee, thr
 instruction_t* emit_binary_operation_with_const_instruction(three_addr_var_t* assignee, three_addr_var_t* op1, Token op, three_addr_const_t* op2); 
 
 /**
+ * Emit a converting move statement. This is basically an assignee, except for the fact that we're explicitly marking that
+ * there will be a conversion(either sign extend or zero extend) that will take place here
+ */
+instruction_t* emit_converting_move_instruction(three_addr_var_t* assignee, three_addr_var_t* op1);
+
+/**
  * Emit a statement that only uses two vars of the form var1 <- var2
  */
 instruction_t* emit_assignment_instruction(three_addr_var_t* assignee, three_addr_var_t* op1);

--- a/oc/compiler/instruction/instruction.h
+++ b/oc/compiler/instruction/instruction.h
@@ -42,6 +42,8 @@ typedef enum{
 	MOVW, //Regular register-to-register or immediate to register
 	MOVL,
 	MOVQ,
+	MOVSX, //Move with sign extension from small to large register
+	MOVZX, //Move with zero extension from small to large register
 	REG_TO_MEM_MOVB,
 	REG_TO_MEM_MOVW,
 	REG_TO_MEM_MOVL,
@@ -577,6 +579,16 @@ three_addr_const_t* emit_long_constant_direct(long long_const, type_symtab_t* sy
  * deal with getting granular when pushing
  */
 instruction_t* emit_push_instruction(three_addr_var_t* pushee);
+
+/**
+ * Emit a movzx(zero extend) instruction
+ */
+instruction_t* emit_movzx_instruction(three_addr_var_t* source, three_addr_var_t* destination);
+
+/**
+ * Emit a movsx(sign extend) instruction
+ */
+instruction_t* emit_movsx_instruction(three_addr_var_t* source, three_addr_var_t* destination);
 
 /**
  * Emit a pop instruction. We only have one kind of popping - quadwords - we don't

--- a/oc/compiler/instruction_selector/instruction_selector.c
+++ b/oc/compiler/instruction_selector/instruction_selector.c
@@ -1782,6 +1782,30 @@ static void handle_dec_instruction(instruction_t* instruction){
 
 
 /**
+ * Handle a converting move statement. This will end up taking the form of
+ * either a movsx or movzx statement, all based on what signedness the destination
+ * expected
+ */
+static void handle_converting_move_instruction(instruction_t* instruction){
+	//We don't need to worry about the variable size here, but we do need to
+	//worry about the signedness
+	u_int8_t is_signed = is_type_signed(instruction->assignee->type);
+
+	//If it is signed, we'll do a sign extending move
+	if(is_signed == TRUE){
+		instruction->instruction_type = MOVSX;
+	//Otherwise we'll do a zero extending move
+	} else {
+		instruction->instruction_type = MOVZX;
+	}
+
+	//Set the source and destination appropriately
+	instruction->source_register = instruction->op1;
+	instruction->destination_register = instruction->assignee;
+}
+
+
+/**
  * Handle a regular move condition
  *
  * We also account for cases where we have variables with indirection levels
@@ -2621,6 +2645,9 @@ static void select_single_instruction_patterns(cfg_t* cfg, instruction_window_t*
 			case THREE_ADDR_CODE_ASSN_STMT:
 			case THREE_ADDR_CODE_ASSN_CONST_STMT:
 				handle_to_register_move_instruction(current);
+				break;
+			case THREE_ADDR_CODE_CONVERTING_ASSIGNMENT_STMT:
+				handle_converting_move_instruction(current);
 				break;
 			case THREE_ADDR_CODE_MEM_ADDR_ASSIGNMENT:
 				handle_address_assignment_instruction(current, cfg->type_symtab, cfg->stack_pointer);

--- a/oc/compiler/register_allocator/register_allocator.c
+++ b/oc/compiler/register_allocator/register_allocator.c
@@ -502,7 +502,8 @@ static void assign_live_range_to_variable(dynamic_array_t* live_ranges, basic_bl
 		} else {
 			printf("Fatal compiler error: variable found with that has no live range\n");
 			print_variable(variable, PRINTING_VAR_INLINE);
-			exit(1);
+			//TODO THIS MUST BE FIXED
+			exit(0);
 		}
 	}
 

--- a/oc/compiler/register_allocator/register_allocator.c
+++ b/oc/compiler/register_allocator/register_allocator.c
@@ -487,7 +487,7 @@ static void assign_live_range_to_variable(dynamic_array_t* live_ranges, basic_bl
 	//For developer flagging
 	if(live_range == NULL){
 		//This is a function parameter, we need to make it ourselves
-		if(variable->linked_var->is_function_paramater == TRUE){
+		if(variable->linked_var != NULL && variable->linked_var->is_function_paramater == TRUE){
 			print_variable(variable, PRINTING_VAR_INLINE);
 			//Create it. Since this is a function parameter, we start at line 0
 			live_range = live_range_alloc(block->function_defined_in, variable->variable_size);
@@ -846,7 +846,6 @@ static void construct_live_ranges_in_block(cfg_t* cfg, dynamic_array_t* live_ran
 		current = current->next_statement;
 	}
 }
-
 
 
 /**

--- a/oc/test_files/relational_testing.ol
+++ b/oc/test_files/relational_testing.ol
@@ -1,0 +1,13 @@
+/**
+* Author: Jack Robbins
+* Testing relational operators
+*/
+
+fn main() -> i32{
+	let mut x:i32 := 3;
+	let mut y:i32 := 3;
+
+	let z:i32 := x >= y;
+
+	ret z;
+}


### PR DESCRIPTION
Resolves #110 

Type conversions now are integrated into the cfg and instruction selector. We make use of certain move logic like movsx and movzx to enable them. A new issue has been opened, #117, that is not resolved by this PR and needs more work