### PR TITLE
Rewrite of Unary Expression handling in CFG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ parser_test: parser.o lexer.o parser_test.o symtab.o lexstack.o heapstack.o type
 	$(CC) -o $(OUT_LOCAL)/parser_test $(OUT_LOCAL)/parser_test.o $(OUT_LOCAL)/parser.o $(OUT_LOCAL)/lexstack.o $(OUT_LOCAL)/lexer.o $(OUT_LOCAL)/heapstack.o $(OUT_LOCAL)/symtab.o $(OUT_LOCAL)/type_system.o $(OUT_LOCAL)/ast.o $(OUT_LOCAL)/call_graph.o $(OUT_LOCAL)/heap_queue.o $(OUT_LOCAL)/lightstack.o $(OUT_LOCAL)/dynamic_array.o $(OUT_LOCAL)/stack_data_area.o $(OUT_LOCAL)/instruction.o
 
 parser_test_debug: parserd.o lexerd.o parser_testd.o symtabd.o lexstack.o heapstackd.o type_systemd.o astd.o call_graphd.o heap_queued.o lightstackd.o dynamic_arrayd.o stack_data_aread.o instructiond.o
-	$(CC) -g -o $(OUT_LOCAL)/debug $(OUT_LOCAL)/parser_testd.o $(OUT_LOCAL)/parserd.o $(OUT_LOCAL)/lexstackd.o $(OUT_LOCAL)/lexerd.o $(OUT_LOCAL)/heapstackd.o $(OUT_LOCAL)/symtabd.o $(OUT_LOCAL)/type_systemd.o $(OUT_LOCAL)/astd.o $(OUT_LOCAL)/call_graphd.o $(OUT_LOCAL)/heap_queued.o $(OUT_LOCAL)/lightstackd.o $(OUT_LOCAL)/dynamic_arrayd.o $(OUT_LOCAL)/stack_data_aread.o $(OUT_LOCAL)/instructiond.o
+	$(CC) -g -o $(OUT_LOCAL)/parser_test_debug $(OUT_LOCAL)/parser_testd.o $(OUT_LOCAL)/parserd.o $(OUT_LOCAL)/lexstackd.o $(OUT_LOCAL)/lexerd.o $(OUT_LOCAL)/heapstackd.o $(OUT_LOCAL)/symtabd.o $(OUT_LOCAL)/type_systemd.o $(OUT_LOCAL)/astd.o $(OUT_LOCAL)/call_graphd.o $(OUT_LOCAL)/heap_queued.o $(OUT_LOCAL)/lightstackd.o $(OUT_LOCAL)/dynamic_arrayd.o $(OUT_LOCAL)/stack_data_aread.o $(OUT_LOCAL)/instructiond.o
 
 symtab_test: symtab.o symtab_test.o lexer.o type_system.o lexstack.o lightstack.o stack_data_area.o instruction.o dynamic_array.o parser.o cfg.o ast.o call_graph.o heap_queue.o heapstack.o jump_table.o 
 	$(CC) -o $(OUT_LOCAL)/symtab_test $(OUT_LOCAL)/lexer.o $(OUT_LOCAL)/symtab_test.o $(OUT_LOCAL)/symtab.o $(OUT_LOCAL)/type_system.o $(OUT_LOCAL)/lexstack.o $(OUT_LOCAL)/lightstack.o $(OUT_LOCAL)/stack_data_area.o $(OUT_LOCAL)/instruction.o $(OUT_LOCAL)/dynamic_array.o $(OUT_LOCAL)/parser.o $(OUT_LOCAL)/cfg.o $(OUT_LOCAL)/ast.o $(OUT_LOCAL)/call_graph.o $(OUT_LOCAL)/heap_queue.o $(OUT_LOCAL)/heapstack.o $(OUT_LOCAL)/jump_table.o
@@ -296,6 +296,9 @@ test_data_area: stack_data_area_test
 
 ptest: parser_test
 	find $(TEST_FILE_DIR) -type f | sort | xargs -n 1 $(OUT_LOCAL)/parser_test -i -d -f
+	
+ptest-debug: parser_test_debug
+	find $(TEST_FILE_DIR) -type f | sort | xargs -n 1 $(OUT_LOCAL)/parser_test_debug -i -d -f
 
 front_test: front_end_test
 	find $(TEST_FILE_DIR) -type f | sort | xargs -n 1 $(OUT_LOCAL)/front_end_test -i -d -f

--- a/oc/compiler/ast/ast.c
+++ b/oc/compiler/ast/ast.c
@@ -17,6 +17,145 @@ static generic_ast_node_t* current_ast_node = NULL;
 
 
 /**
+ * This helper function negates a constant node's value
+ */
+void negate_constant_value(generic_ast_node_t* constant_node){
+	//Grab the constant node out
+	constant_ast_node_t* const_node = ((constant_ast_node_t*)(constant_node->node));
+
+	//Switch based on the value here
+	switch(const_node->constant_type){
+		//Negate these accordingly
+		case INT_CONST_FORCE_U:
+		case INT_CONST:
+			const_node->int_val = const_node->int_val * -1;
+			break;
+		case FLOAT_CONST:
+			const_node->float_val = const_node->float_val * -1;
+			break;
+		case CHAR_CONST:
+			const_node->char_val = const_node->char_val * -1;
+		case LONG_CONST_FORCE_U:
+		case LONG_CONST:
+			const_node->long_val = const_node->long_val * -1;
+		//This should never happen
+		default:
+			return;
+	}
+}
+
+
+/**
+ * This helper function decrements a constant node's value
+ */
+void decrement_constant_value(generic_ast_node_t* constant_node){
+	//Grab the constant node out
+	constant_ast_node_t* const_node = ((constant_ast_node_t*)(constant_node->node));
+
+	//Switch based on the value here
+	switch(const_node->constant_type){
+		//Negate these accordingly
+		case INT_CONST_FORCE_U:
+		case INT_CONST:
+			const_node->int_val = const_node->int_val - 1;
+			break;
+		case FLOAT_CONST:
+			const_node->float_val = const_node->float_val - 1;
+			break;
+		case CHAR_CONST:
+			const_node->char_val = const_node->char_val - 1;
+		case LONG_CONST_FORCE_U:
+		case LONG_CONST:
+			const_node->long_val = const_node->long_val - 1;
+		//This should never happen
+		default:
+			return;
+	}
+}
+
+
+/**
+ * This helper function increments a constant node's value
+ */
+void increment_constant_value(generic_ast_node_t* constant_node){
+	//Grab the constant node out
+	constant_ast_node_t* const_node = ((constant_ast_node_t*)(constant_node->node));
+
+	//Switch based on the value here
+	switch(const_node->constant_type){
+		//Negate these accordingly
+		case INT_CONST_FORCE_U:
+		case INT_CONST:
+			const_node->int_val = const_node->int_val + 1;
+			break;
+		case FLOAT_CONST:
+			const_node->float_val = const_node->float_val + 1;
+			break;
+		case CHAR_CONST:
+			const_node->char_val = const_node->char_val + 1;
+		case LONG_CONST_FORCE_U:
+		case LONG_CONST:
+			const_node->long_val = const_node->long_val + 1;
+		//This should never happen
+		default:
+			return;
+	}
+}
+
+
+/**
+ * This helper function will logically not a consant node's value
+ */
+void logical_not_constant_value(generic_ast_node_t* constant_node){
+	//Grab the constant node out
+	constant_ast_node_t* const_node = ((constant_ast_node_t*)(constant_node->node));
+
+	//Switch based on the value here
+	switch(const_node->constant_type){
+		//Negate these accordingly
+		case INT_CONST_FORCE_U:
+		case INT_CONST:
+			const_node->int_val = !(const_node->int_val);
+			break;
+		case CHAR_CONST:
+			const_node->char_val = !(const_node->char_val);
+		case LONG_CONST_FORCE_U:
+		case LONG_CONST:
+			const_node->long_val = !(const_node->long_val);
+		//This should never happen
+		default:
+			return;
+	}
+}
+
+
+/**
+ * This helper function will logically not a consant node's value
+ */
+void bitwise_not_constant_value(generic_ast_node_t* constant_node){
+	//Grab the constant node out
+	constant_ast_node_t* const_node = ((constant_ast_node_t*)(constant_node->node));
+
+	//Switch based on the value here
+	switch(const_node->constant_type){
+		//Negate these accordingly
+		case INT_CONST_FORCE_U:
+		case INT_CONST:
+			const_node->int_val = ~(const_node->int_val);
+			break;
+		case CHAR_CONST:
+			const_node->char_val = ~(const_node->char_val);
+		case LONG_CONST_FORCE_U:
+		case LONG_CONST:
+			const_node->long_val = ~(const_node->long_val);
+		//This should never happen
+		default:
+			return;
+	}
+}
+
+
+/**
  * A utility function for duplicating nodes
  */
 generic_ast_node_t* duplicate_node(const generic_ast_node_t* node){

--- a/oc/compiler/ast/ast.h
+++ b/oc/compiler/ast/ast.h
@@ -179,6 +179,31 @@ struct asm_inline_stmt_ast_node_t{
 };
 
 /**
+ * This helper function negates a constant node's value
+ */
+void negate_constant_value(generic_ast_node_t* constant_node);
+
+/**
+ * This helper function decrements a constant node's value
+ */
+void decrement_constant_value(generic_ast_node_t* constant_node);
+
+/**
+ * This helper function increments a constant node's value
+ */
+void increment_constant_value(generic_ast_node_t* constant_node);
+
+/**
+ * This helper function will logically not a consant node's value
+ */
+void bitwise_not_constant_value(generic_ast_node_t* constant_node);
+
+/**
+ * This helper function will logically not a consant node's value
+ */
+void logical_not_constant_value(generic_ast_node_t* constant_node);
+
+/**
  * Global node allocation function
  */
 generic_ast_node_t* ast_node_alloc(ast_node_class_t CLASS, side_type_t side);

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -2734,6 +2734,11 @@ static three_addr_var_t* emit_postoperation_code(basic_block_t* basic_block, thr
  * and array access
  */
 static three_addr_var_t* emit_postfix_expr_code(basic_block_t* basic_block, generic_ast_node_t* postfix_parent, u_int8_t temp_assignment_required, u_int8_t is_branch_ending){
+	//If this is itself not a postfix expression, we need to lose it here
+	if(postfix_parent->CLASS != AST_NODE_CLASS_POSTFIX_EXPR){
+		return emit_primary_expr_code(basic_block, postfix_parent, temp_assignment_required, is_branch_ending);
+	}
+
 	//We'll first want a cursor
 	generic_ast_node_t* cursor = postfix_parent->first_child;
 	

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -106,8 +106,8 @@ static statement_result_package_t emit_binary_expression(basic_block_t* basic_bl
 static statement_result_package_t emit_ternary_expression(basic_block_t* basic_block, generic_ast_node_t* ternary_operation, u_int8_t is_branch_ending);
 static three_addr_var_t* emit_binary_operation_with_constant(basic_block_t* basic_block, three_addr_var_t* assignee, three_addr_var_t* op1, Token op, three_addr_const_t* constant, u_int8_t is_branch_ending);
 static three_addr_var_t* emit_function_call(basic_block_t* basic_block, generic_ast_node_t* function_call_node, u_int8_t is_branch_ending);
-static three_addr_var_t* emit_unary_expression(basic_block_t* basic_block, generic_ast_node_t* unary_expr_parent, u_int8_t temp_assignment_required, u_int8_t is_branch_ending);
-static statement_result_package_t emit_expr_code(basic_block_t* basic_block, generic_ast_node_t* expr_node, u_int8_t is_branch_ending, u_int8_t check_for_coniditional);
+static three_addr_var_t* emit_unary_expression(basic_block_t* basic_block, generic_ast_node_t* unary_expression, u_int8_t temp_assignment_required, u_int8_t is_branch_ending);
+static statement_result_package_t emit_expression(basic_block_t* basic_block, generic_ast_node_t* expr_node, u_int8_t is_branch_ending, u_int8_t check_for_coniditional);
 static basic_block_t* basic_block_alloc(u_int32_t estimated_execution_frequency);
 
 /**
@@ -2253,7 +2253,7 @@ static void emit_ret(basic_block_t* basic_block, generic_ast_node_t* ret_node, u
 	//not happen all the time naturally. As such, we need this assignment here
 	if(ret_node->first_child != NULL){
 		//Perform the binary operation here
-		package = emit_expr_code(basic_block, ret_node->first_child, is_branch_ending, FALSE);
+		package = emit_expression(basic_block, ret_node->first_child, is_branch_ending, FALSE);
 
 		//Emit the temp assignment
 		instruction_t* assn_stmt = emit_assignment_instruction(emit_temp_var(package.assignee->type), package.assignee);
@@ -3105,30 +3105,16 @@ static three_addr_var_t* emit_unary_operation(basic_block_t* basic_block, generi
  * 	
  * 	<postfix-expression> | <unary-operator> <cast-expression> | typesize(<type-specifier>) | sizeof(<logical-or-expression>) 
  */
-static three_addr_var_t* emit_unary_expression(basic_block_t* basic_block, generic_ast_node_t* unary_expr_parent, u_int8_t temp_assignment_required, u_int8_t is_branch_ending){
-	//The last two instances return a constant node. If that's the case, we'll just emit a constant node here
-	if(unary_expr_parent->CLASS == AST_NODE_CLASS_CONSTANT){
-		//Let the helper deal with it
-		return emit_constant_assignment(basic_block, unary_expr_parent, is_branch_ending);
-	}
-
-	//If it isn't a constant, then this node should have children
-	generic_ast_node_t* first_child = unary_expr_parent->first_child;
-
-	//Since we know that this node has childen, we'll now go through
-	//and decide what to do with it based on its class
-	switch(first_child->CLASS){
-		//Leverage the helper for this method
-		case AST_NODE_CLASS_POSTFIX_EXPR:
-			return emit_postfix_expr_code(basic_block, first_child, temp_assignment_required, is_branch_ending);
-
-		//We can also see a unary operator here. In this case, we'll let the unary operator helper function take care of it
-		case AST_NODE_CLASS_UNARY_OPERATOR:
-			return emit_unary_operation(basic_block, unary_expr_parent, temp_assignment_required, is_branch_ending);
-				
-		//By defualt, emit a primary expression
+static three_addr_var_t* emit_unary_expression(basic_block_t* basic_block, generic_ast_node_t* unary_expression, u_int8_t temp_assignment_required, u_int8_t is_branch_ending){
+	//Switch based on what class this node actually is
+	switch(unary_expression->CLASS){
+		//If it's actually a unary expression, we can do some processing
+		//If we see the actual node here, we know that we are actually doing a unary operation
+		case AST_NODE_CLASS_UNARY_EXPR:	
+			return emit_unary_operation(basic_block, unary_expression, temp_assignment_required, is_branch_ending);
+		//Otherwise if we don't see this node, we instead know that this is really a postfix expression of some kind
 		default:
-			return emit_primary_expr_code(basic_block, first_child, temp_assignment_required, is_branch_ending);
+			return emit_postfix_expr_code(basic_block, unary_expression, temp_assignment_required, is_branch_ending);
 	}
 }
 
@@ -3191,7 +3177,7 @@ static statement_result_package_t emit_ternary_expression(basic_block_t* origin_
 	cursor = cursor->next_sibling;
 
 	//Emit this in our new if block
-	statement_result_package_t if_branch = emit_expr_code(if_block, cursor, is_branch_ending, TRUE);
+	statement_result_package_t if_branch = emit_expression(if_block, cursor, is_branch_ending, TRUE);
 
 	//We'll now create a conditional move for the if branch into the result
 	instruction_t* if_assignment = emit_assignment_instruction(result, if_branch.assignee);
@@ -3206,7 +3192,7 @@ static statement_result_package_t emit_ternary_expression(basic_block_t* origin_
 	cursor = cursor->next_sibling;
 
 	//Emit this in our else block
-	statement_result_package_t else_branch = emit_expr_code(else_block, cursor, is_branch_ending, TRUE);
+	statement_result_package_t else_branch = emit_expression(else_block, cursor, is_branch_ending, TRUE);
 
 	//We'll now create a conditional move for the else branch into the result
 	instruction_t* else_assignment = emit_assignment_instruction(result, else_branch.assignee);
@@ -3253,28 +3239,14 @@ static statement_result_package_t emit_binary_expression(basic_block_t* basic_bl
 	//Our assignee - this can change dynamically based on the kind of operator
 	three_addr_var_t* assignee;
 
-	//Is the cursor here a unary expression or a constant? If so just emit that
-	switch(logical_or_expr->CLASS){
-		//Process a unary expression(these are usually idents)
-		case AST_NODE_CLASS_UNARY_EXPR:
-			//Return the temporary character from here
-			package.assignee = emit_unary_expression(basic_block, logical_or_expr, FALSE, is_branch_ending);
-			return package;
-
-		//Process a constant, we may have these in here directly
-		case AST_NODE_CLASS_CONSTANT:
-			package.assignee = emit_constant_assignment(basic_block, logical_or_expr, is_branch_ending);
-			return package;
-
-		//We could also have a ternary operation here
-		case AST_NODE_CLASS_TERNARY_EXPRESSION:
-			package.assignee = emit_ternary_expression(basic_block, logical_or_expr, is_branch_ending).assignee;
-			return package;
-		
-		//Break out by default
-		default:
-			break;
+	//Have we hit the so-called "root level" here? If we have, then we're just going to pass this
+	//down to another rule
+	if(logical_or_expr->CLASS != AST_NODE_CLASS_BINARY_EXPR){
+		package.assignee = emit_unary_expression(basic_block, logical_or_expr, FALSE, is_branch_ending);
+		return package;
 	}
+
+	//Otherwise, when we get here, we know that we have a binary expression of some kind
 
 	//Otherwise we actually have a binary operation of some kind
 	//Grab a cursor
@@ -3374,7 +3346,7 @@ static statement_result_package_t emit_binary_expression(basic_block_t* basic_bl
  * These statements almost always involve some kind of assignment "<-" and generate temporary
  * variables
  */
-static statement_result_package_t emit_expr_code(basic_block_t* basic_block, generic_ast_node_t* expr_node, u_int8_t is_branch_ending, u_int8_t check_for_coniditional){
+static statement_result_package_t emit_expression(basic_block_t* basic_block, generic_ast_node_t* expr_node, u_int8_t is_branch_ending, u_int8_t check_for_coniditional){
 	//A cursor for tree traversal
 	generic_ast_node_t* cursor;
 	symtab_variable_record_t* assigned_var;
@@ -3397,7 +3369,7 @@ static statement_result_package_t emit_expr_code(basic_block_t* basic_block, gen
 			cursor = cursor->next_sibling;
 
 			//Now emit the right hand expression
-			statement_result_package_t package = emit_expr_code(basic_block, cursor, is_branch_ending, FALSE);
+			statement_result_package_t package = emit_expression(basic_block, cursor, is_branch_ending, FALSE);
 
 			//Finally we'll construct the whole thing
 			instruction_t* stmt = emit_assignment_instruction(left_hand_var, package.assignee);
@@ -3434,12 +3406,13 @@ static statement_result_package_t emit_expr_code(basic_block_t* basic_block, gen
 			result_package.assignee = emit_ternary_expression(basic_block, expr_node, is_branch_ending).assignee;
 			return result_package;
 
-		case AST_NODE_CLASS_UNARY_EXPR:
+		default:
 			/**
 			* This is a very special check where we look for any if(x) kind of statements that just require a
 			* left hand temp assignment
+			* TODO THIS MAY NO LONGER WORK
 			*/
-			if(check_for_coniditional == TRUE && expr_node->first_child->CLASS == AST_NODE_CLASS_IDENTIFIER){
+			if(check_for_coniditional == TRUE && expr_node->first_child != NULL && expr_node->first_child->CLASS == AST_NODE_CLASS_IDENTIFIER){
 				//If this is the case, then we need to just emit the temporary value and be done with it
 				result_package.assignee =  emit_identifier(basic_block, expr_node->first_child, TRUE, TRUE);
 				//Signedness is irrelevant here because any jumps would just be "je/jne"
@@ -3450,10 +3423,6 @@ static statement_result_package_t emit_expr_code(basic_block_t* basic_block, gen
 				//Again signedness is irrelevant here because any jumps would just be "je/jne"
 				return result_package;
 			}
-
-		//We should never actually hit this, it's just to stop the compiler from complaining
-		default:
-			return result_package;
 	}
 }
 
@@ -3500,7 +3469,7 @@ static three_addr_var_t* emit_function_call(basic_block_t* basic_block, generic_
 	//So long as this isn't NULL
 	while(param_cursor != NULL){
 		//Emit whatever we have here into the basic block
-		statement_result_package_t package = emit_expr_code(basic_block, param_cursor, is_branch_ending, FALSE);
+		statement_result_package_t package = emit_expression(basic_block, param_cursor, is_branch_ending, FALSE);
 
 		//We'll also need to emit a temp assignment here. This is because we need to move everything into given
 		//registers before a function call
@@ -4064,7 +4033,7 @@ static statement_result_package_t visit_for_statement(values_package_t* values){
 				break;
 			default:
 				//Add it's child in as a statement to the entry block
-				emit_expr_code(for_stmt_entry_block, ast_cursor->first_child, TRUE, FALSE);
+				emit_expression(for_stmt_entry_block, ast_cursor->first_child, TRUE, FALSE);
 		}
 	}
 
@@ -4090,7 +4059,7 @@ static statement_result_package_t visit_for_statement(values_package_t* values){
 	//If the second one is not blank
 	if(ast_cursor->first_child != NULL){
 		//This is always the first part of the repeating block
-		condition_block_vals = emit_expr_code(condition_block, ast_cursor->first_child, TRUE, TRUE);
+		condition_block_vals = emit_expression(condition_block, ast_cursor->first_child, TRUE, TRUE);
 	//It is impossible for the second one to be blank
 	} else {
 		print_parse_message(PARSE_ERROR, "Fatal internal compiler error. Should not have gotten here if blank", for_stmt_node->line_number);
@@ -4110,7 +4079,7 @@ static statement_result_package_t visit_for_statement(values_package_t* values){
 	//If the third one is not blank
 	if(ast_cursor->first_child != NULL){
 		//Emit the update expression
-		emit_expr_code(for_stmt_update_block, ast_cursor->first_child, FALSE, FALSE);
+		emit_expression(for_stmt_update_block, ast_cursor->first_child, FALSE, FALSE);
 	}
 	
 	//Unconditional jump to condition block
@@ -4263,7 +4232,7 @@ static statement_result_package_t visit_do_while_statement(values_package_t* val
 	}
 
 	//Add the conditional check into the end here
-	statement_result_package_t package = emit_expr_code(compound_stmt_end, ast_cursor->next_sibling, TRUE, TRUE);
+	statement_result_package_t package = emit_expression(compound_stmt_end, ast_cursor->next_sibling, TRUE, TRUE);
 
 	//Now we'll make do our necessary connnections. The direct successor of this end block is the true
 	//exit block
@@ -4330,7 +4299,7 @@ static statement_result_package_t visit_while_statement(values_package_t* values
 	generic_ast_node_t* ast_cursor = while_stmt_node->first_child;
 
 	//The entry block contains our expression statement
-	statement_result_package_t package = emit_expr_code(while_statement_entry_block, ast_cursor, TRUE, TRUE);
+	statement_result_package_t package = emit_expression(while_statement_entry_block, ast_cursor, TRUE, TRUE);
 
 	//The very next node is a compound statement
 	ast_cursor = ast_cursor->next_sibling;
@@ -4435,7 +4404,7 @@ static statement_result_package_t visit_if_statement(values_package_t* values){
 	generic_ast_node_t* cursor = values->initial_node->first_child;
 
 	//Add whatever our conditional is into the starting block
-	statement_result_package_t package = emit_expr_code(entry_block, cursor, TRUE, TRUE);
+	statement_result_package_t package = emit_expression(entry_block, cursor, TRUE, TRUE);
 
 	//No we'll move one step beyond, the next node must be a compound statement
 	cursor = cursor->next_sibling;
@@ -4518,7 +4487,7 @@ static statement_result_package_t visit_if_statement(values_package_t* values){
 		emit_jump(temp, current_entry_block, JUMP_TYPE_JMP, TRUE, FALSE);
 
 		//So we've seen the else-if clause. Let's grab the expression first
-		package = emit_expr_code(current_entry_block, else_if_cursor, TRUE, TRUE);
+		package = emit_expression(current_entry_block, else_if_cursor, TRUE, TRUE);
 
 		//Advance it up -- we should now have a compound statement
 		else_if_cursor = else_if_cursor->next_sibling;
@@ -4877,7 +4846,7 @@ static statement_result_package_t visit_switch_statement(values_package_t* value
 	
 	//The very first thing should be an expression telling us what to switch on
 	//There should be some kind of expression here
-	statement_result_package_t package1 = emit_expr_code(starting_block, expression_node, TRUE, TRUE);
+	statement_result_package_t package1 = emit_expression(starting_block, expression_node, TRUE, TRUE);
 
 	//Unsigned by default
 	u_int8_t is_signed = is_type_signed(package1.assignee->type);
@@ -4890,7 +4859,7 @@ static statement_result_package_t visit_switch_statement(values_package_t* value
 	emit_jump(starting_block, default_block, jump_lower_than, TRUE, FALSE);
 
 	//Due to the way temp assignment works, we actually need to re-emit this whole thing
-	statement_result_package_t package2 = emit_expr_code(starting_block, expression_node, TRUE, TRUE);
+	statement_result_package_t package2 = emit_expression(starting_block, expression_node, TRUE, TRUE);
 
 	//Next step -> if we're above the maximum, jump to default
 	emit_binary_operation_with_constant(starting_block, package2.assignee, package2.assignee, G_THAN, upper_bound, TRUE);
@@ -4900,7 +4869,7 @@ static statement_result_package_t visit_switch_statement(values_package_t* value
 	emit_jump(starting_block, default_block, jump_greater_than, TRUE, FALSE);
 
 	//Due to the way temp assignment works, we actually need to re-emit this whole thing
-	statement_result_package_t package3 = emit_expr_code(starting_block, expression_node, TRUE, TRUE);
+	statement_result_package_t package3 = emit_expression(starting_block, expression_node, TRUE, TRUE);
 
 	//Now that all this is done, we can use our jump table for the rest
 	//We'll now need to cut the value down by whatever our offset was	
@@ -5173,7 +5142,7 @@ static basic_block_t* visit_compound_statement(values_package_t* values){
 			//Otherwise, we have a conditional continue here
 			} else {
 				//Emit the expression code into the current statement
-				statement_result_package_t package = emit_expr_code(current_block, ast_cursor->first_child, TRUE, TRUE);
+				statement_result_package_t package = emit_expression(current_block, ast_cursor->first_child, TRUE, TRUE);
 				//Decide the appropriate jump statement -- direct path here
 				jump_type_t jump_type = select_appropriate_jump_stmt(package.operator, JUMP_CATEGORY_NORMAL, is_type_signed(package.assignee->type));
 
@@ -5250,7 +5219,7 @@ static basic_block_t* visit_compound_statement(values_package_t* values){
 				basic_block_t* new_block = basic_block_alloc(1);
 
 				//First let's emit the conditional code
-				statement_result_package_t ret_package = emit_expr_code(current_block, ast_cursor->first_child, TRUE, TRUE);
+				statement_result_package_t ret_package = emit_expression(current_block, ast_cursor->first_child, TRUE, TRUE);
 
 				//Now based on whatever we have in here, we'll emit the appropriate jump type(direct jump)
 				jump_type_t jump_type = select_appropriate_jump_stmt(ret_package.operator, JUMP_CATEGORY_NORMAL, is_type_signed(ret_package.assignee->type));
@@ -5417,7 +5386,7 @@ static basic_block_t* visit_compound_statement(values_package_t* values){
 			}
 			
 			//Also emit the simplified machine code
-			emit_expr_code(current_block, ast_cursor, FALSE, FALSE);
+			emit_expression(current_block, ast_cursor, FALSE, FALSE);
 		}
 
 		//Advance to the next child
@@ -5610,7 +5579,7 @@ static statement_result_package_t visit_let_statement(generic_ast_node_t* node, 
 	let_results.assignee = left_hand_var;
 
 	//Now emit whatever binary expression code that we have
-	statement_result_package_t package = emit_expr_code(lead_block, node->first_child, is_branch_ending, FALSE);
+	statement_result_package_t package = emit_expression(lead_block, node->first_child, is_branch_ending, FALSE);
 
 	//The actual statement is the assignment of right to left
 	instruction_t* assignment_statement = emit_assignment_instruction(left_hand_var, package.assignee);

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -1926,44 +1926,19 @@ static generic_ast_node_t* unary_expression(FILE* fl, side_type_t side){
 	lexitem_t lookahead;
 	//Is this assignable
 	variable_assignability_t is_assignable = ASSIGNABLE;
-	//For folding cases
-	Token unary_op_tok = BLANK;
 
 	//Let's see what we have
 	lookahead = get_next_token(fl, &parser_line_num, NOT_SEARCHING_FOR_CONSTANT);
 	//Save this for searching
-	unary_op_tok = lookahead.tok;
+	Token unary_op_tok = lookahead.tok;
 
 	//If this is not a unary operator, we don't need to go any more
 	if(is_unary_operator(unary_op_tok) == FALSE){
 		//Push it back
 		push_back_token(lookahead);
-		//We'll still make a top level tree here to avoid ambiguity
-		generic_ast_node_t* unary_expr_node = ast_node_alloc(AST_NODE_CLASS_UNARY_EXPR, side);
 
 		//Let this handle the heavy lifting
-		generic_ast_node_t* postfix_expr_node = postfix_expression(fl, side);
-
-		//If this is NULL, just send it up the chain
-		if(postfix_expr_node->CLASS == AST_NODE_CLASS_ERR_NODE){
-			return postfix_expr_node;
-		}
-
-		//Otherwise he is the unary expression node here
-		add_child_node(unary_expr_node, postfix_expr_node);
-
-		//Carry the var through
-		unary_expr_node->variable = postfix_expr_node->variable;
-
-		//This type info is also sent up
-		unary_expr_node->inferred_type = postfix_expr_node->inferred_type;
-		//Store the line number
-		unary_expr_node->line_number = parser_line_num;
-		//Duplicate the assignability
-		unary_expr_node->is_assignable = postfix_expr_node->is_assignable;
-
-		//Postfix already has type inference built in
-		return unary_expr_node;
+		return postfix_expression(fl, side);
 	}
 
 	//Otherwise, if we get down here we know that we have a unary operator
@@ -2182,8 +2157,6 @@ static generic_ast_node_t* unary_expression(FILE* fl, side_type_t side){
 	add_child_node(unary_node, cast_expr);
 
 	//Store the type that we have here
-	unary_node->inferred_type = return_type;
-	//Store this down the chain as well
 	unary_node->inferred_type = return_type;
 	//Store the line number
 	unary_node->line_number = parser_line_num;

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -1730,149 +1730,6 @@ static generic_ast_node_t* postfix_expression(FILE* fl, side_type_t side){
 }
 
 
-/**
- * This helper function negates a constant node's value
- */
-static void negate_constant_value(generic_ast_node_t* constant_node){
-	//Grab the constant node out
-	constant_ast_node_t* const_node = ((constant_ast_node_t*)(constant_node->node));
-
-	//Switch based on the value here
-	switch(const_node->constant_type){
-		//Negate these accordingly
-		case INT_CONST_FORCE_U:
-		case INT_CONST:
-			const_node->int_val = const_node->int_val * -1;
-			break;
-		case FLOAT_CONST:
-			const_node->float_val = const_node->float_val * -1;
-			break;
-		case CHAR_CONST:
-			const_node->char_val = const_node->char_val * -1;
-		case LONG_CONST_FORCE_U:
-		case LONG_CONST:
-			const_node->long_val = const_node->long_val * -1;
-		//This should never happen
-		default:
-			print_parse_message(PARSE_ERROR, "Attempt to negate an invalid value", constant_node->line_number);
-			exit(0);
-	}
-}
-
-
-/**
- * This helper function decrements a constant node's value
- */
-static void decrement_constant_value(generic_ast_node_t* constant_node){
-	//Grab the constant node out
-	constant_ast_node_t* const_node = ((constant_ast_node_t*)(constant_node->node));
-
-	//Switch based on the value here
-	switch(const_node->constant_type){
-		//Negate these accordingly
-		case INT_CONST_FORCE_U:
-		case INT_CONST:
-			const_node->int_val = const_node->int_val - 1;
-			break;
-		case FLOAT_CONST:
-			const_node->float_val = const_node->float_val - 1;
-			break;
-		case CHAR_CONST:
-			const_node->char_val = const_node->char_val - 1;
-		case LONG_CONST_FORCE_U:
-		case LONG_CONST:
-			const_node->long_val = const_node->long_val - 1;
-		//This should never happen
-		default:
-			print_parse_message(PARSE_ERROR, "Attempt to decrement an invalid value", constant_node->line_number);
-			exit(0);
-	}
-}
-
-
-/**
- * This helper function increments a constant node's value
- */
-static void increment_constant_value(generic_ast_node_t* constant_node){
-	//Grab the constant node out
-	constant_ast_node_t* const_node = ((constant_ast_node_t*)(constant_node->node));
-
-	//Switch based on the value here
-	switch(const_node->constant_type){
-		//Negate these accordingly
-		case INT_CONST_FORCE_U:
-		case INT_CONST:
-			const_node->int_val = const_node->int_val + 1;
-			break;
-		case FLOAT_CONST:
-			const_node->float_val = const_node->float_val + 1;
-			break;
-		case CHAR_CONST:
-			const_node->char_val = const_node->char_val + 1;
-		case LONG_CONST_FORCE_U:
-		case LONG_CONST:
-			const_node->long_val = const_node->long_val + 1;
-		//This should never happen
-		default:
-			print_parse_message(PARSE_ERROR, "Attempt to increment an invalid value", constant_node->line_number);
-			exit(0);
-	}
-}
-
-
-/**
- * This helper function will logically not a consant node's value
- */
-static void logical_not_constant_value(generic_ast_node_t* constant_node){
-	//Grab the constant node out
-	constant_ast_node_t* const_node = ((constant_ast_node_t*)(constant_node->node));
-
-	//Switch based on the value here
-	switch(const_node->constant_type){
-		//Negate these accordingly
-		case INT_CONST_FORCE_U:
-		case INT_CONST:
-			const_node->int_val = !(const_node->int_val);
-			break;
-		case CHAR_CONST:
-			const_node->char_val = !(const_node->char_val);
-		case LONG_CONST_FORCE_U:
-		case LONG_CONST:
-			const_node->long_val = !(const_node->long_val);
-		//This should never happen
-		default:
-			print_parse_message(PARSE_ERROR, "Attempt to logically not an invalid value", constant_node->line_number);
-			exit(0);
-	}
-}
-
-
-/**
- * This helper function will logically not a consant node's value
- */
-static void bitwise_not_constant_value(generic_ast_node_t* constant_node){
-	//Grab the constant node out
-	constant_ast_node_t* const_node = ((constant_ast_node_t*)(constant_node->node));
-
-	//Switch based on the value here
-	switch(const_node->constant_type){
-		//Negate these accordingly
-		case INT_CONST_FORCE_U:
-		case INT_CONST:
-			const_node->int_val = ~(const_node->int_val);
-			break;
-		case CHAR_CONST:
-			const_node->char_val = ~(const_node->char_val);
-		case LONG_CONST_FORCE_U:
-		case LONG_CONST:
-			const_node->long_val = ~(const_node->long_val);
-		//This should never happen
-		default:
-			print_parse_message(PARSE_ERROR, "Attempt to bitwise not an invalid value", constant_node->line_number);
-			exit(0);
-	}
-}
-
 
 /**
  * Is a given token a unary operator
@@ -2104,7 +1961,7 @@ static generic_ast_node_t* unary_expression(FILE* fl, side_type_t side){
 
 			//This counts as mutation -- unless it's a constant
 			if(cast_expr->variable != NULL){
-				cast_expr->variable->assigned_to = 1;
+				cast_expr->variable->assigned_to = TRUE;
 			}
 
 			//This is only not assignable if we have a basic variable
@@ -2120,31 +1977,6 @@ static generic_ast_node_t* unary_expression(FILE* fl, side_type_t side){
 		//In reality, we should never reach here
 		default:
 			return print_and_return_error("Fatal internal compiler error: invalid unary operation", parser_line_num);
-	}
-
-	//If we have a constant here, we have a chance to do some optimizations
-	if(cast_expr->first_child->CLASS == AST_NODE_CLASS_CONSTANT){
-		//Go based on this
-		switch (unary_op_tok) {
-			case MINUS:
-				negate_constant_value(cast_expr->first_child);
-				return cast_expr;
-			case MINUSMINUS:
-				decrement_constant_value(cast_expr->first_child);
-				return cast_expr;
-			case PLUSPLUS:
-				increment_constant_value(cast_expr->first_child);
-				return cast_expr;
-			case L_NOT:
-				logical_not_constant_value(cast_expr->first_child);
-				return cast_expr;
-			case B_NOT:
-				bitwise_not_constant_value(cast_expr->first_child);
-				return cast_expr;
-			//Just do nothing
-			default:
-				break;
-		}
 	}
 
 	//One we get here, we have both nodes that we need

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -1979,6 +1979,35 @@ static generic_ast_node_t* unary_expression(FILE* fl, side_type_t side){
 			return print_and_return_error("Fatal internal compiler error: invalid unary operation", parser_line_num);
 	}
 
+	//If we have a constant here, we have a chance to do some optimizations
+	if(cast_expr->CLASS == AST_NODE_CLASS_CONSTANT){
+		//Go based on this
+		switch (unary_op_tok) {
+			case MINUS:
+				negate_constant_value(cast_expr);
+				return cast_expr;
+
+			case MINUSMINUS:
+				decrement_constant_value(cast_expr);
+				return cast_expr;
+
+			case PLUSPLUS:
+				increment_constant_value(cast_expr);
+				return cast_expr;
+
+			case L_NOT:
+				logical_not_constant_value(cast_expr);
+				return cast_expr;
+
+			case B_NOT:
+				bitwise_not_constant_value(cast_expr);
+				return cast_expr;
+			//Just do nothing
+			default:
+				break;
+		}
+	}
+
 	//One we get here, we have both nodes that we need
 	generic_ast_node_t* unary_node = ast_node_alloc(AST_NODE_CLASS_UNARY_EXPR, side);
 	

--- a/oc/test_files/simple_let.ol
+++ b/oc/test_files/simple_let.ol
@@ -1,0 +1,9 @@
+/**
+* Author: Jack Robbins
+* Simplest version of a program
+*/
+
+fn main() -> i32 {
+	let mut x:i32 := 81;
+	ret x;
+}


### PR DESCRIPTION
Close #145 
Close #140 

Unary Expressions now no longer produce an extra ast_node unless it is necessary. This greatly reduces memory consumption as previously, ever statement no matter how simple had to be nested in a unary expression.