### PR TITLE
Rewrite cfg pattern to use new result package strategy

### DIFF
--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -217,7 +217,6 @@ dynamic_array_t* compute_reverse_post_order_traversal(basic_block_t* entry, u_in
 		//Go all the way to the bottom
 		while(entry->block_type != BLOCK_TYPE_FUNC_EXIT){
 			entry = entry->direct_successor;
-			printf("STUCK\n\n");
 		}
 	}
 
@@ -1046,8 +1045,6 @@ static void calculate_dominance_frontiers(cfg_t* cfg){
 
 			//While cursor is not the immediate dominator of block
 			while(cursor != immediate_dominator(block)){
-				printf("STUCK IDOM\n");
-
 				//Add block to cursor's dominance frontier set
 				add_block_to_dominance_frontier(cursor, block);
 				

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -1046,6 +1046,8 @@ static void calculate_dominance_frontiers(cfg_t* cfg){
 
 			//While cursor is not the immediate dominator of block
 			while(cursor != immediate_dominator(block)){
+				printf("STUCK IDOM\n");
+
 				//Add block to cursor's dominance frontier set
 				add_block_to_dominance_frontier(cursor, block);
 				
@@ -4105,9 +4107,6 @@ static statement_result_package_t visit_for_statement(values_package_t* values){
 	//because that is what repeats on continue
 	statement_result_package_t compound_statement_results = visit_compound_statement(&compound_stmt_values);
 
-	//For our eventual token
-	statement_result_package_t expression_package;
-
 	//If it's null, that's actually ok here
 	if(compound_statement_results.starting_block == NULL){
 		//We'll make sure that the start points to this block
@@ -4119,9 +4118,6 @@ static statement_result_package_t visit_for_statement(values_package_t* values){
 
 		//Make the condition block jump to the exit. This is an inverse jump
 		emit_jump(condition_block, for_stmt_exit_block, jump_type, TRUE, TRUE);
-
-		//The direct successor to the entry block is the exit block, for efficiency reasons
-		for_stmt_entry_block->direct_successor = for_stmt_exit_block;
 
 		//And we're done
 		return result_package;
@@ -5808,5 +5804,5 @@ cfg_t* build_cfg(front_end_results_package_t* results, u_int32_t* num_errors, u_
 	rename_all_variables(cfg);
 
 	//Give back the reference
-	return cfg;
+	return cfg //FORCING COMP FAILURE
 }

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -5390,9 +5390,11 @@ static statement_result_package_t visit_compound_statement(values_package_t* val
 		ast_cursor = ast_cursor->next_sibling;
 	}
 
-	//We always return the starting block
-	//It is possible that we have a completely NULL compound statement. This returns
-	//NULL in that event
+	//If we make it down here - we still need to ensure that results are packaged properly
+	results.starting_block = starting_block;
+	results.final_block = current_block;
+
+	//Give back results
 	return results;
 }
 

--- a/oc/compiler/cfg/cfg.h
+++ b/oc/compiler/cfg/cfg.h
@@ -67,7 +67,9 @@ typedef enum{
 struct cfg_t{
 	//This dynamic array contains all of the function
 	//entry blocks for each function that we have
-	dynamic_array_t* function_blocks;
+	dynamic_array_t* function_entry_blocks;
+	//Store the exit blocks as well. This makes RPO traversal much easier
+	dynamic_array_t* function_exit_blocks;
 	//An array of all blocks that are 
 	//All created blocks
 	dynamic_array_t* created_blocks;

--- a/oc/compiler/instruction_selector/instruction_selector.c
+++ b/oc/compiler/instruction_selector/instruction_selector.c
@@ -4001,9 +4001,9 @@ static basic_block_t* order_blocks(cfg_t* cfg){
 	heap_queue_t* queue = heap_queue_alloc();
 
 	//For each function
-	for(u_int16_t _ = 0; _ < cfg->function_blocks->current_index; _++){
+	for(u_int16_t _ = 0; _ < cfg->function_entry_blocks->current_index; _++){
 		//Grab the function block out
-		basic_block_t* func_block = dynamic_array_get_at(cfg->function_blocks, _);
+		basic_block_t* func_block = dynamic_array_get_at(cfg->function_entry_blocks, _);
 
 		//This function start block is the begging of our BFS	
 		enqueue(queue, func_block);

--- a/oc/compiler/optimizer/optimizer.c
+++ b/oc/compiler/optimizer/optimizer.c
@@ -1000,12 +1000,12 @@ static void optimize_compound_logic(cfg_t* cfg){
  */
 static void clean(cfg_t* cfg){
 	//For each function in the CFG
-	for(u_int16_t _ = 0; _ < cfg->function_blocks->current_index; _++){
+	for(u_int16_t _ = 0; _ < cfg->function_entry_blocks->current_index; _++){
 		//Have we seen change(modification) at all?
 		u_int8_t changed;
 
 		//Grab the function block out
-		basic_block_t* function_entry = dynamic_array_get_at(cfg->function_blocks, _);
+		basic_block_t* function_entry = dynamic_array_get_at(cfg->function_entry_blocks, _);
 
 		//The postorder traversal array
 		dynamic_array_t* postorder;

--- a/oc/compiler/register_allocator/register_allocator.c
+++ b/oc/compiler/register_allocator/register_allocator.c
@@ -555,9 +555,9 @@ static void calculate_liveness_sets(cfg_t* cfg){
 		difference_found = FALSE;
 
 		//Run through all of the blocks backwards
-		for(int16_t i = cfg->function_blocks->current_index - 1; i >= 0; i--){
+		for(int16_t i = cfg->function_entry_blocks->current_index - 1; i >= 0; i--){
 			//Grab the block out
-			basic_block_t* func_entry = dynamic_array_get_at(cfg->function_blocks, i);
+			basic_block_t* func_entry = dynamic_array_get_at(cfg->function_entry_blocks, i);
 
 			//Reset the registers in here while we're at it
 			memset(func_entry->function_defined_in->used_registers, 0, sizeof(u_int8_t) * 17);
@@ -1403,9 +1403,9 @@ static void spill(cfg_t* cfg, dynamic_array_t* live_ranges, live_range_t* spill_
 	//Optimization - live-ranges are function level, so we'll just go through the function
 	//blocks until we find one that matches this function
 	basic_block_t* function_block;
-	for(u_int16_t i = 0; i < cfg->function_blocks->current_index; i++){
+	for(u_int16_t i = 0; i < cfg->function_entry_blocks->current_index; i++){
 		//Grab the block out
-		function_block = dynamic_array_get_at(cfg->function_blocks, i);
+		function_block = dynamic_array_get_at(cfg->function_entry_blocks, i);
 
 		//We've got our match
 		if(function_block->function_defined_in == spill_range->function_defined_in){
@@ -1872,7 +1872,7 @@ static void insert_all_stack_and_saving_logic(cfg_t* cfg){
 	heap_stack_t* heap_stack = heap_stack_alloc();
 
 	//Run through every function entry point in the CFG
-	for(u_int16_t i = 0; i < cfg->function_blocks->current_index; i++){
+	for(u_int16_t i = 0; i < cfg->function_entry_blocks->current_index; i++){
 		//Reset the heap stack every time
 		reset_heap_stack(heap_stack);
 
@@ -1880,7 +1880,7 @@ static void insert_all_stack_and_saving_logic(cfg_t* cfg){
 		instruction_t* last_push_instruction = NULL;
 
 		//Grab it out
-		basic_block_t* current_function_entry = dynamic_array_get_at(cfg->function_blocks, i);
+		basic_block_t* current_function_entry = dynamic_array_get_at(cfg->function_entry_blocks, i);
 
 		//Grab the function defined in as well
 		symtab_function_record_t* function = current_function_entry->function_defined_in;

--- a/oc/test_files/simple_for.ol
+++ b/oc/test_files/simple_for.ol
@@ -1,0 +1,15 @@
+/**
+* Author: Jack Robbins
+* Testing simple for loop functionality
+*/
+
+fn main() -> i32 {
+	declare mut x:i32;
+	let mut y:i32 := 3;
+
+	for(x := 0; x < 800; ++x){
+		y += x;
+	}
+
+	ret y;
+}

--- a/oc/test_files/test_prog11.ol
+++ b/oc/test_files/test_prog11.ol
@@ -29,7 +29,7 @@ fn main() -> i32{
 
 	let a_temp:i32 := b_arr[2];
 
-	defer {a++}
+	defer {a++;}
 	
 	
 


### PR DESCRIPTION
Closes #139 
Closes #121 

Rewrite cfg pattern to use new result package strategy. This avoids the need for any direct successor drilling.