### PR TITLE
Returning in switch

### DIFF
--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -5279,6 +5279,12 @@ static cfg_result_package_t visit_c_style_switch_statement(generic_ast_node_t* r
 		emit_jump(current_block, ending_block, JUMP_TYPE_JMP, TRUE, FALSE);
 	}
 
+	//If the ending block has no successors at all, that means that we've returned through every control path. Instead
+	//of using the ending block, we can change it to be the function ending block
+	if(ending_block->successors == NULL || ending_block->successors->current_index == 0){
+		result_package.final_block = function_exit_block;
+	}
+
 	//Run through the entire jump table. Any nodes that are not occupied(meaning there's no case statement with that value)
 	//will be set to point to the default block
 	for(u_int16_t i = 0; i < root_level_block->jump_table->num_nodes; i++){

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -4156,7 +4156,7 @@ void dealloc_cfg(cfg_t* cfg){
 	//Run through all of the blocks here and delete them
 	for(u_int16_t i = 0; i < cfg->created_blocks->current_index; i++){
 		//Use this to deallocate
-		basic_block_dealloc(dynamic_array_get_at(cfg->created_blocks, i));
+		//basic_block_dealloc(dynamic_array_get_at(cfg->created_blocks, i));
 	}
 
 	//Destroy all variables
@@ -4331,6 +4331,7 @@ static basic_block_t* merge_blocks(basic_block_t* a, basic_block_t* b){
 
 	//If b has a jump table, we'll need to add this in as well
 	a->jump_table = b->jump_table;
+	b->jump_table = NULL;
 
 	//If b executes more than A and it's now a part of A, we'll need to bump up A appropriately
 	if(a->estimated_execution_frequency < b->estimated_execution_frequency){
@@ -6419,6 +6420,14 @@ static cfg_result_package_t visit_compound_statement(generic_ast_node_t* root_no
 
 				//The current block is always what's directly at the end
 				current_block = generic_results.final_block;
+
+				//If this is the exit block, it means that we returned through every control path
+				//in here
+				if(current_block == function_exit_block){
+					results.starting_block = starting_block;
+					results.final_block = current_block;
+					return results;
+				}
 
 				break;
 

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -4156,7 +4156,7 @@ void dealloc_cfg(cfg_t* cfg){
 	//Run through all of the blocks here and delete them
 	for(u_int16_t i = 0; i < cfg->created_blocks->current_index; i++){
 		//Use this to deallocate
-		//basic_block_dealloc(dynamic_array_get_at(cfg->created_blocks, i));
+		basic_block_dealloc(dynamic_array_get_at(cfg->created_blocks, i));
 	}
 
 	//Destroy all variables
@@ -5281,7 +5281,7 @@ static cfg_result_package_t visit_c_style_switch_statement(generic_ast_node_t* r
 
 	//If the ending block has no successors at all, that means that we've returned through every control path. Instead
 	//of using the ending block, we can change it to be the function ending block
-	if(ending_block->successors == NULL || ending_block->successors->current_index == 0){
+	if(ending_block->predecessors == NULL || ending_block->predecessors->current_index == 0){
 		result_package.final_block = function_exit_block;
 	}
 

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -6014,6 +6014,17 @@ static cfg_result_package_t visit_statement_chain(generic_ast_node_t* first_node
 				break;
 		}
 
+		//If this is the exit block, it means that we returned through every control path
+		//in here and there is no point in moving forward. We'll simply return
+		if(current_block == function_exit_block){
+			//Warn that we have unreachable code here
+			if(ast_cursor->next_sibling != NULL){
+				print_cfg_message(WARNING, "Unreachable code detected after segment that returns in all control paths", ast_cursor->next_sibling->line_number);
+			}
+
+			break;
+		}
+
 		//Advance to the next child
 		ast_cursor = ast_cursor->next_sibling;
 	}
@@ -6421,14 +6432,6 @@ static cfg_result_package_t visit_compound_statement(generic_ast_node_t* root_no
 				//The current block is always what's directly at the end
 				current_block = generic_results.final_block;
 
-				//If this is the exit block, it means that we returned through every control path
-				//in here
-				if(current_block == function_exit_block){
-					results.starting_block = starting_block;
-					results.final_block = current_block;
-					return results;
-				}
-
 				break;
 
 			case AST_NODE_CLASS_C_STYLE_SWITCH_STMT:
@@ -6508,6 +6511,17 @@ static cfg_result_package_t visit_compound_statement(generic_ast_node_t* root_no
 				emit_expression(current_block, ast_cursor, FALSE, FALSE);
 				
 				break;
+		}
+
+		//If this is the exit block, it means that we returned through every control path
+		//in here and there is no point in moving forward. We'll simply return
+		if(current_block == function_exit_block){
+			//Warn that we have unreachable code here
+			if(ast_cursor->next_sibling != NULL){
+				print_cfg_message(WARNING, "Unreachable code detected after segment that returns in all control paths", ast_cursor->next_sibling->line_number);
+			}
+
+			break;
 		}
 
 		//Advance to the next child

--- a/oc/test_files/returning_in_c_switch.ol
+++ b/oc/test_files/returning_in_c_switch.ol
@@ -1,0 +1,34 @@
+/**
+* Author: Jack Robbins
+* This program is made to test returning in a c style switch
+*/
+
+fn return_c_switch(arg:i32) -> i32{
+	switch(arg){
+		case 2:
+			ret 32;
+
+		case 1;
+			ret 2;
+
+		case 7:
+		case 4:
+			ret 3;
+
+		case 3:
+			ret 5;
+
+		case 6:
+			ret 22;
+
+		default:
+			ret 111;
+	}
+
+	//Shouldn't even touch this
+	ret 22;
+}
+
+fn main(arg:i32, argv:char**) -> i32{
+	ret @return_c_switch(arg);
+}

--- a/oc/test_files/returning_in_c_switch.ol
+++ b/oc/test_files/returning_in_c_switch.ol
@@ -8,7 +8,7 @@ fn return_c_switch(arg:i32) -> i32{
 		case 2:
 			ret 32;
 
-		case 1;
+		case 1:
 			ret 2;
 
 		case 7:

--- a/oc/test_files/returning_in_ollie_switch.ol
+++ b/oc/test_files/returning_in_ollie_switch.ol
@@ -26,6 +26,9 @@ fn return_ollie_switch(arg:i32) -> i32{
 			ret 111;
 		}
 	}
+
+	//Shouldn't even touch this
+	ret 22;
 }
 
 fn main(arg:i32, argv:char**) -> i32{

--- a/oc/test_files/returning_in_ollie_switch.ol
+++ b/oc/test_files/returning_in_ollie_switch.ol
@@ -1,0 +1,33 @@
+/**
+* Author: Jack Robbins
+* This program is made to test returning in an ollie style switch
+*/
+
+fn return_ollie_switch(arg:i32) -> i32{
+	switch(arg){
+		case 2 -> {
+			ret 32;
+		}
+		case 1 -> {
+			ret 2;
+		}
+		case 4 -> {
+			ret 3;
+		}
+		case 3 -> {
+			ret 5;
+		}
+
+		case 6 -> {
+			ret 22;
+		}
+
+		default -> {
+			ret 111;
+		}
+	}
+}
+
+fn main(arg:i32, argv:char**) -> i32{
+	ret @return_ollie_switch(arg);
+}


### PR DESCRIPTION
Returning in switch

Fixes to the way that returning through all control paths in a switch statement are handled.

Closes #183 