### PR TITLE
Instruction selector fixes & fixes to conditionals with BLANK operators

### DIFF
--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -3390,6 +3390,8 @@ static cfg_result_package_t emit_ternary_expression(basic_block_t* starting_bloc
 
 	//Select the jump type for our conditional
 	jump_type_t jump = select_appropriate_jump_stmt(expression_package.operator, JUMP_CATEGORY_NORMAL, is_signed);
+
+	//TODO HERE we need some conditional logic which inserts the test command if the operator is blank MOVING DOES NOT SET FLAGS
 	
 	//Now we'll emit a jump to the if block and else block
 	emit_jump(current_block, if_block, expression_package.assignee, jump, is_branch_ending, FALSE);

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -2384,6 +2384,11 @@ void emit_jump(basic_block_t* basic_block, basic_block_t* dest_block, three_addr
 
 	//Add this into the first block
 	add_statement(basic_block, stmt);
+
+	//This conditional result now counts as a variable that has been used, because this jump relies on it
+	if(conditional_result != NULL){
+		add_used_variable(basic_block, conditional_result);
+	}
 }
 
 

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -5018,7 +5018,7 @@ static cfg_result_package_t visit_if_statement(generic_ast_node_t* root_node){
 			//If the operator is blank, we need to emit a test instruction
 			if(package.operator == BLANK){
 				//Emit the testing instruction
-	 			conditional_decider = emit_test_code(entry_block, package.assignee, package.assignee, TRUE);
+	 			conditional_decider = emit_test_code(current_entry_block, package.assignee, package.assignee, TRUE);
 			}
 
 			//Emit a jump based on the decider

--- a/oc/compiler/cfg/cfg.h
+++ b/oc/compiler/cfg/cfg.h
@@ -203,7 +203,7 @@ void calculate_all_control_relations(cfg_t* cfg, u_int8_t build_fresh, u_int8_t 
 /**
  * Emit a jump statement directly into a block
  */
-void emit_jump(basic_block_t* basic_block, basic_block_t* dest_block, jump_type_t type, u_int8_t is_branch_ending, u_int8_t inverse_jump);
+void emit_jump(basic_block_t* basic_block, basic_block_t* dest_block, three_addr_var_t* conditional_result, jump_type_t type, u_int8_t is_branch_ending, u_int8_t inverse_jump);
 
 /**
  * For DEBUGGING purposes - we will print all of the blocks in the control

--- a/oc/compiler/instruction/instruction.c
+++ b/oc/compiler/instruction/instruction.c
@@ -1415,7 +1415,7 @@ void print_three_addr_code_stmt(FILE* fl, instruction_t* stmt){
 			fprintf(fl, " <- test ");
 			print_variable(fl, stmt->op1, PRINTING_VAR_INLINE);
 			fprintf(fl, ", ");
-			print_variable(fl, stmt->op1, PRINTING_VAR_INLINE);
+			print_variable(fl, stmt->op2, PRINTING_VAR_INLINE);
 			fprintf(fl, "\n");
 			break;
 
@@ -3080,7 +3080,7 @@ instruction_t* emit_dec_instruction(three_addr_var_t* decrementee){
  *
  * Test instructions inherently have no assignee as they don't modify registers
  */
-instruction_t* emit_test_statement(three_addr_var_t* assignee, three_addr_var_t* op1){
+instruction_t* emit_test_statement(three_addr_var_t* assignee, three_addr_var_t* op1, three_addr_var_t* op2){
 	//First we'll allocate it
 	instruction_t* stmt = calloc(1, sizeof(instruction_t));
 
@@ -3090,6 +3090,7 @@ instruction_t* emit_test_statement(three_addr_var_t* assignee, three_addr_var_t*
 	//Assign the assignee and op1
 	stmt->assignee = assignee;
 	stmt->op1 = op1;
+	stmt->op2 = op2;
 
 	//Assign the function too
 	stmt->function = current_function;

--- a/oc/compiler/instruction/instruction.c
+++ b/oc/compiler/instruction/instruction.c
@@ -232,6 +232,8 @@ variable_size_t select_type_size(generic_type_t* type){
 				//These are 32 bit(double word)
 				case S_INT32:
 				case U_INT32:
+				case SIGNED_INT_CONST:
+				case UNSIGNED_INT_CONST:
 					size = DOUBLE_WORD;
 					break;
 
@@ -3060,6 +3062,28 @@ instruction_t* emit_dec_instruction(three_addr_var_t* decrementee){
 	dec_stmt->function = current_function;
 	//And give it back
 	return dec_stmt;
+}
+
+
+/**
+ * Emit a test instruction
+ *
+ * Test instructions inherently have no assignee as they don't modify registers
+ */
+instruction_t* emit_test_statement(three_addr_var_t* assignee, three_addr_var_t* op1, three_addr_var_t* op2){
+	//First we'll allocate it
+	instruction_t* stmt = calloc(1, sizeof(instruction_t));
+
+	//We'll now set the type
+	stmt->CLASS = THREE_ADDR_CODE_TEST_STMT;
+
+	//Then we'll set op1 and op2 to be the source registers
+	stmt->assignee = assignee;
+	stmt->op1 = op1;
+	stmt->op2 = op2;
+
+	//And now we'll give it back
+	return stmt;
 }
 
 

--- a/oc/compiler/instruction/instruction.c
+++ b/oc/compiler/instruction/instruction.c
@@ -3101,6 +3101,47 @@ instruction_t* emit_test_statement(three_addr_var_t* assignee, three_addr_var_t*
 
 
 /**
+ * Emit a test instruction directly - bypassing the instruction selection step
+ *
+ * Test instructions inherently have no assignee as they don't modify registers
+ *
+ * NOTE: This may only be used DURING the process of register selection
+ */
+instruction_t* emit_direct_test_instruction(three_addr_var_t* op1, three_addr_var_t* op2){
+	//First we'll allocate it
+	instruction_t* instruction = calloc(1, sizeof(instruction_t));
+
+	//We'll need the size to select the appropriate instruction
+	variable_size_t size = select_variable_size(op1);
+
+	//Select the size appropriately
+	switch(size){
+		case QUAD_WORD:
+			instruction->instruction_type = TESTQ;
+			break;
+		case DOUBLE_WORD:
+			instruction->instruction_type = TESTL;
+			break;
+		case WORD:
+			instruction->instruction_type = TESTW;
+			break;
+		case BYTE:
+			instruction->instruction_type = TESTB;
+			break;
+		default:
+			break;
+	}
+
+	//Then we'll set op1 and op2 to be the source registers
+	instruction->source_register = op1;
+	instruction->source_register2 = op2;
+
+	//And now we'll give it back
+	return instruction;
+}
+
+
+/**
  * Emit a decrement instruction
  */
 instruction_t* emit_inc_instruction(three_addr_var_t* incrementee){

--- a/oc/compiler/instruction/instruction.c
+++ b/oc/compiler/instruction/instruction.c
@@ -1409,6 +1409,16 @@ void print_three_addr_code_stmt(FILE* fl, instruction_t* stmt){
 			fprintf(fl, "\n");
 			break;
 
+		case THREE_ADDR_CODE_TEST_STMT:
+			//First print the assignee
+			print_variable(fl, stmt->assignee, PRINTING_VAR_INLINE);
+			fprintf(fl, " <- test ");
+			print_variable(fl, stmt->op1, PRINTING_VAR_INLINE);
+			fprintf(fl, ", ");
+			print_variable(fl, stmt->op1, PRINTING_VAR_INLINE);
+			fprintf(fl, "\n");
+			break;
+
 		case THREE_ADDR_CODE_ASSN_CONST_STMT:
 			//First print out the assignee
 			print_variable(fl, stmt->assignee, PRINTING_VAR_INLINE);
@@ -3070,17 +3080,19 @@ instruction_t* emit_dec_instruction(three_addr_var_t* decrementee){
  *
  * Test instructions inherently have no assignee as they don't modify registers
  */
-instruction_t* emit_test_statement(three_addr_var_t* assignee, three_addr_var_t* op1, three_addr_var_t* op2){
+instruction_t* emit_test_statement(three_addr_var_t* assignee, three_addr_var_t* op1){
 	//First we'll allocate it
 	instruction_t* stmt = calloc(1, sizeof(instruction_t));
 
 	//We'll now set the type
 	stmt->CLASS = THREE_ADDR_CODE_TEST_STMT;
 
-	//Then we'll set op1 and op2 to be the source registers
+	//Assign the assignee and op1
 	stmt->assignee = assignee;
 	stmt->op1 = op1;
-	stmt->op2 = op2;
+
+	//Assign the function too
+	stmt->function = current_function;
 
 	//And now we'll give it back
 	return stmt;

--- a/oc/compiler/instruction/instruction.h
+++ b/oc/compiler/instruction/instruction.h
@@ -348,6 +348,8 @@ typedef enum{
 	THREE_ADDR_CODE_ASM_INLINE_STMT,
 	//A "Load effective address(lea)" instruction
 	THREE_ADDR_CODE_LEA_STMT,
+	//A test instruction
+	THREE_ADDR_CODE_TEST_STMT,
 	//An indirect jump address calculation instruction, very similar to lea
 	THREE_ADDR_CODE_INDIR_JUMP_ADDR_CALC_STMT,
 	//A phi function - for SSA analysis only
@@ -804,6 +806,11 @@ instruction_t* emit_inc_instruction(three_addr_var_t* incrementee);
  * Emit a decrement instruction
  */
 instruction_t* emit_dec_instruction(three_addr_var_t* decrementee);
+
+/**
+ * Emit a test statement 
+ */
+instruction_t* emit_test_statement(three_addr_var_t* assignee, three_addr_var_t* op1, three_addr_var_t* op2);
 
 /**
  * Emit a negation(negX) statement

--- a/oc/compiler/instruction/instruction.h
+++ b/oc/compiler/instruction/instruction.h
@@ -810,7 +810,7 @@ instruction_t* emit_dec_instruction(three_addr_var_t* decrementee);
 /**
  * Emit a test statement 
  */
-instruction_t* emit_test_statement(three_addr_var_t* assignee, three_addr_var_t* op1);
+instruction_t* emit_test_statement(three_addr_var_t* assignee, three_addr_var_t* op1, three_addr_var_t* op2);
 
 /**
  * Emit a negation(negX) statement

--- a/oc/compiler/instruction/instruction.h
+++ b/oc/compiler/instruction/instruction.h
@@ -813,6 +813,11 @@ instruction_t* emit_dec_instruction(three_addr_var_t* decrementee);
 instruction_t* emit_test_statement(three_addr_var_t* assignee, three_addr_var_t* op1, three_addr_var_t* op2);
 
 /**
+ * Directly emit a test instruction - bypassing three_addr_code entirely - going right to a selected instruction
+ */
+instruction_t* emit_direct_test_instruction(three_addr_var_t* op1, three_addr_var_t* op2);
+
+/**
  * Emit a negation(negX) statement
  */
 instruction_t* emit_neg_instruction(three_addr_var_t* assignee, three_addr_var_t* negatee);

--- a/oc/compiler/instruction/instruction.h
+++ b/oc/compiler/instruction/instruction.h
@@ -810,7 +810,7 @@ instruction_t* emit_dec_instruction(three_addr_var_t* decrementee);
 /**
  * Emit a test statement 
  */
-instruction_t* emit_test_statement(three_addr_var_t* assignee, three_addr_var_t* op1, three_addr_var_t* op2);
+instruction_t* emit_test_statement(three_addr_var_t* assignee, three_addr_var_t* op1);
 
 /**
  * Emit a negation(negX) statement

--- a/oc/compiler/instruction_selector/instruction_selector.c
+++ b/oc/compiler/instruction_selector/instruction_selector.c
@@ -256,7 +256,7 @@ static void print_instruction_window(instruction_window_t* window){
  *
  * NOTE: This may only be used DURING the process of register selection
  */
-static instruction_t* emit_test_instruction(three_addr_var_t* op1, three_addr_var_t* op2){
+static instruction_t* emit_direct_test_instruction(three_addr_var_t* op1, three_addr_var_t* op2){
 	//First we'll allocate it
 	instruction_t* instruction = calloc(1, sizeof(instruction_t));
 
@@ -2358,7 +2358,7 @@ static void handle_logical_not_instruction(cfg_t* cfg, instruction_window_t* win
 
 	//Now we'll need to generate three new instructions
 	//First comes the test command. We're testing this against itself
-	instruction_t* test_inst = emit_test_instruction(logical_not->assignee, logical_not->assignee); 
+	instruction_t* test_inst = emit_direct_test_instruction(logical_not->assignee, logical_not->assignee); 
 	//Ensure that we set all these flags too
 	test_inst->block_contained_in = logical_not->block_contained_in;
 	test_inst->is_branch_ending = logical_not->is_branch_ending;
@@ -2478,7 +2478,7 @@ static void handle_logical_and_instruction(cfg_t* cfg, instruction_window_t* win
 	instruction_t* after_logical_and = logical_and->next_statement;
 
 	//Let's first emit our test instruction
-	instruction_t* first_test = emit_test_instruction(logical_and->op1, logical_and->op1);
+	instruction_t* first_test = emit_direct_test_instruction(logical_and->op1, logical_and->op1);
 
 	//We'll need this type for our setne's
 	generic_type_t* unsigned_int8_type = lookup_type_name_only(cfg->type_symtab, "u8")->type;
@@ -2487,7 +2487,7 @@ static void handle_logical_and_instruction(cfg_t* cfg, instruction_window_t* win
 	instruction_t* first_set = emit_setne_instruction(emit_temp_var(unsigned_int8_type));
 	
 	//Now we'll need the second test
-	instruction_t* second_test = emit_test_instruction(logical_and->op2, logical_and->op2);
+	instruction_t* second_test = emit_direct_test_instruction(logical_and->op2, logical_and->op2);
 
 	//Now the second setne
 	instruction_t* second_set = emit_setne_instruction(emit_temp_var(unsigned_int8_type));

--- a/oc/compiler/instruction_selector/instruction_selector.c
+++ b/oc/compiler/instruction_selector/instruction_selector.c
@@ -250,47 +250,6 @@ static void print_instruction_window(instruction_window_t* window){
 
 
 /**
- * Emit a test instruction
- *
- * Test instructions inherently have no assignee as they don't modify registers
- *
- * NOTE: This may only be used DURING the process of register selection
- */
-static instruction_t* emit_direct_test_instruction(three_addr_var_t* op1, three_addr_var_t* op2){
-	//First we'll allocate it
-	instruction_t* instruction = calloc(1, sizeof(instruction_t));
-
-	//We'll need the size to select the appropriate instruction
-	variable_size_t size = select_variable_size(op1);
-
-	//Select the size appropriately
-	switch(size){
-		case QUAD_WORD:
-			instruction->instruction_type = TESTQ;
-			break;
-		case DOUBLE_WORD:
-			instruction->instruction_type = TESTL;
-			break;
-		case WORD:
-			instruction->instruction_type = TESTW;
-			break;
-		case BYTE:
-			instruction->instruction_type = TESTB;
-			break;
-		default:
-			break;
-	}
-
-	//Then we'll set op1 and op2 to be the source registers
-	instruction->source_register = op1;
-	instruction->source_register2 = op2;
-
-	//And now we'll give it back
-	return instruction;
-}
-
-
-/**
  * Emit a conversion instruction for division preparation
  *
  * We use this during the process of emitting division instructions

--- a/oc/compiler/instruction_selector/instruction_selector.c
+++ b/oc/compiler/instruction_selector/instruction_selector.c
@@ -2578,6 +2578,15 @@ static void handle_not_instruction(instruction_t* instruction){
 
 
 /**
+ * Handle a test instruction. The test instruction's op1 is acutally duplicated
+ * to be both of its inputs in this case
+ */
+static void handle_test_instruction(instruction_t* instruction){
+
+}
+
+
+/**
  * Select instructions that follow a singular pattern. This one single pass will run after
  * the pattern selector ran and perform one-to-one mappings on whatever is left.
  */
@@ -2974,7 +2983,7 @@ static void select_instruction_patterns(cfg_t* cfg, instruction_window_t* window
 		//Handle the testing statement
 		case THREE_ADDR_CODE_TEST_STMT:
 			//Let the helper do it
-			//TODO
+			handle_test_instruction(instruction);
 			break;
 			
 		default:

--- a/oc/compiler/instruction_selector/instruction_selector.c
+++ b/oc/compiler/instruction_selector/instruction_selector.c
@@ -2582,7 +2582,30 @@ static void handle_not_instruction(instruction_t* instruction){
  * to be both of its inputs in this case
  */
 static void handle_test_instruction(instruction_t* instruction){
+	//Find out what size we have
+	variable_size_t size = select_variable_size(instruction->assignee);
 
+	switch(size){
+		case QUAD_WORD:
+			instruction->instruction_type = TESTQ;
+			break;
+		case DOUBLE_WORD:
+			instruction->instruction_type = TESTL;
+			break;
+		case WORD:
+			instruction->instruction_type = TESTW;
+			break;
+		case BYTE:
+			instruction->instruction_type = TESTB;
+			break;
+		default:
+			break;
+	}
+
+	//This actually has no real destination register, the assignee was a dummy
+	//It does have 2 source registers however
+	instruction->source_register = instruction->op1;
+	instruction->source_register2 = instruction->op2;
 }
 
 

--- a/oc/compiler/instruction_selector/instruction_selector.c
+++ b/oc/compiler/instruction_selector/instruction_selector.c
@@ -2970,6 +2970,13 @@ static void select_instruction_patterns(cfg_t* cfg, instruction_window_t* window
 			//Let the helper do it
 			handle_not_instruction(instruction);
 			break;
+
+		//Handle the testing statement
+		case THREE_ADDR_CODE_TEST_STMT:
+			//Let the helper do it
+			//TODO
+			break;
+			
 		default:
 			break;
 	}

--- a/oc/compiler/optimizer/optimizer.c
+++ b/oc/compiler/optimizer/optimizer.c
@@ -1757,33 +1757,8 @@ static void mark(cfg_t* cfg){
 			//will be our jump to if
 			instruction_t* jump_to_if = rdf_block_stmt;
 
-			/**
-			 * One final thing to check here - our conditional statement. This should really be a foregone
-			 * conclusion - but it never hurts to check
-			 *
-			 * If it's NULL or somehow a jump, we'll bail out. This really should never happen, it's just
-			 * here so it won't crash if something goes terribly wrong
-			 */
-			rdf_block_stmt = rdf_block_stmt->previous_statement;
-			if(rdf_block_stmt == NULL || rdf_block_stmt->CLASS == THREE_ADDR_CODE_JUMP_STMT){
-				continue;
-			}
-
-			//We survived - so this is our conditional statement
-			instruction_t* conditional_stmt = rdf_block_stmt;
-
-			//Now we'll go through and mark these statements
-			//Mark the conditional and add it to the worklist
-			if(conditional_stmt->mark == FALSE){
-				printf("Marking conditional statement: ");
-				print_three_addr_code_stmt(stdout, conditional_stmt);
-				printf("\n");
-
-				//Mark
-				conditional_stmt->mark = TRUE;
-				//Add to list
-				dynamic_array_add(worklist, conditional_stmt);
-			}
+			//Mark and add the definitions of the op1 that this conditional jump relies on as important
+			mark_and_add_definition(cfg, jump_to_if, jump_to_if->op1, stmt->function, worklist);
 
 			//Now mark the jump to if. We don't need to add this one to
 			//any list - there's nothing else to mark

--- a/oc/compiler/optimizer/optimizer.c
+++ b/oc/compiler/optimizer/optimizer.c
@@ -270,7 +270,7 @@ static u_int8_t branch_reduce(cfg_t* cfg, dynamic_array_t* postorder){
 					delete_all_branching_statements(current);
 					//Once we're done deleting, we'll emit a jump right to that jumping to
 					//block. This constitutes our "fold"
-					emit_jump(current, end_branch_target, JUMP_TYPE_JMP, TRUE, FALSE);
+					emit_jump(current, end_branch_target, NULL, JUMP_TYPE_JMP, TRUE, FALSE);
 					//This does mean that we've changed
 					changed = TRUE;
 				}

--- a/oc/compiler/register_allocator/register_allocator.c
+++ b/oc/compiler/register_allocator/register_allocator.c
@@ -497,7 +497,6 @@ static void assign_live_range_to_variable(dynamic_array_t* live_ranges, basic_bl
 		} else {
 			printf("Fatal compiler error: variable found with that has no live range\n");
 			print_variable(stdout, variable, PRINTING_VAR_INLINE);
-			//TODO THIS MUST BE FIXED
 			exit(0);
 		}
 	}

--- a/oc/test_files/constant_conditional_check.ol
+++ b/oc/test_files/constant_conditional_check.ol
@@ -1,0 +1,18 @@
+/**
+* Author: Jack Robbins
+* This file checks the case where you have a constant as a conditional: i.e while(1) or something of the sort
+*/
+
+pub fn main() -> i32 {
+	let mut x:i32 := 232;
+
+	//Checking this
+	while(1){
+		x--;
+
+		break when (x == 32);
+	}
+
+	//To stop the optimizer
+	ret x;
+}

--- a/oc/test_files/constant_conditional_check.ol
+++ b/oc/test_files/constant_conditional_check.ol
@@ -6,11 +6,36 @@
 pub fn main() -> i32 {
 	let mut x:i32 := 232;
 
-	//Checking this
+	//Checking while
 	while(1){
 		x--;
 
 		break when (x == 32);
+	}
+
+
+	//Checking do-while
+	do{
+		x--;
+
+		break when (x == 32);
+	} while(1);
+
+	//checking for
+	for(let mut a:i32 := 32; a; a--){
+		x--;
+	}
+
+	//Check that it works for if
+	if(1){
+		x--;
+	}
+
+	//Check that it works for else if
+	if(x == 1){
+		x++;
+	} else if (1){
+		x--;
 	}
 
 	//To stop the optimizer

--- a/oc/test_files/variable_conditional_check.ol
+++ b/oc/test_files/variable_conditional_check.ol
@@ -1,0 +1,19 @@
+/**
+* Author: Jack Robbins
+* This file checks the case where you have a constant as a conditional: i.e while(1) or something of the sort
+*/
+
+pub fn main() -> i32 {
+	let mut x:i32 := 232;
+	let mut y:i32 := 3;
+
+	//Checking this
+	while(y){
+		x--;
+
+		break when (x == 32);
+	}
+
+	//To stop the optimizer
+	ret x;
+}

--- a/oc/test_files/variable_conditional_check.ol
+++ b/oc/test_files/variable_conditional_check.ol
@@ -3,15 +3,35 @@
 * This file checks the case where you have a constant as a conditional: i.e while(1) or something of the sort
 */
 
-pub fn main() -> i32 {
+pub fn main(argc:i32, argv:char**) -> i32 {
 	let mut x:i32 := 232;
-	let mut y:i32 := 3;
 
-	//Checking this
-	while(y){
+	//Checking while
+	while(*argv){
+		x--;
+
+		break when (x);
+	}
+
+
+	//Checking do-while
+	do{
 		x--;
 
 		break when (x == 32);
+	} while(argc);
+
+
+	//Check that it works for if
+	if(*argv){
+		x--;
+	}
+
+	//Check that it works for else if
+	if(argc){
+		x++;
+	} else if (**argv){
+		x--;
 	}
 
 	//To stop the optimizer


### PR DESCRIPTION
Emergency fixes for instruction selector simplifications erroneously removing certain constant assignments.

Fixes #217 