### PR TITLE
Replace := with =

### DIFF
--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -1701,9 +1701,9 @@ static void build_dominator_trees(cfg_t* cfg, u_int8_t build_fresh){
 
 /**
  * if(x0 == 0){
- * 	asn x1 := 2;
+ * 	x1 = 2;
  * } else {
- * 	asn x2 := 3;
+ * 	x2 = 3;
  * }
  * 
  * x3 <- phi(x1, x2)

--- a/oc/compiler/lexer/lexer.c
+++ b/oc/compiler/lexer/lexer.c
@@ -945,6 +945,8 @@ char* operator_to_string(Token op){
 			return "/";
 		case MOD:
 			return "%";
+		case EQUALS:
+			return "=";
 		case PLUSEQ:
 			return "+=";
 		case MINUSEQ:

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -138,7 +138,7 @@ void print_parse_message(parse_message_type_t message_type, char* info, u_int16_
  */
 static u_int8_t is_assignment_operator(Token op){
 	switch(op){
-		case COLONEQ:
+		case EQUALS:
 		case LSHIFTEQ:
 		case RSHIFTEQ:
 		case XOREQ:
@@ -1224,9 +1224,9 @@ static generic_ast_node_t* assignment_expression(FILE* fl){
 	//What is our final type?
 	generic_type_t* final_type = NULL;
 
-	//If we have a generic assignment(:=), we can just do the assignability
+	//If we have a generic assignment(=), we can just do the assignability
 	//check
-	if(assignment_operator == COLONEQ){
+	if(assignment_operator == EQUALS){
 		/**
 		 * We will make use of the types assignable module here, as the rules are slightly 
 		 * different than the types compatible rule
@@ -8017,8 +8017,8 @@ static generic_ast_node_t* let_statement(FILE* fl, u_int8_t is_global){
 	lookahead = get_next_token(fl, &parser_line_num, NOT_SEARCHING_FOR_CONSTANT);
 
 	//Assop is mandatory here
-	if(lookahead.tok != COLONEQ){
-		return print_and_return_error("Assignment operator(:=) required after identifier in let statement", parser_line_num);
+	if(lookahead.tok != EQUALS){
+		return print_and_return_error("Assignment operator(=) required after identifier in let statement", parser_line_num);
 	}
 
 	//Now we need to see a valid initializer

--- a/oc/compiler/symtab/symtab.c
+++ b/oc/compiler/symtab/symtab.c
@@ -1072,7 +1072,7 @@ void print_variable_name(symtab_variable_record_t* record){
 			
 			//We'll print out some abbreviated stuff with the let record
 			if(record->declare_or_let == 1){
-				printf(" := <initializer>;\n\n");
+				printf(" = <initializer>;\n\n");
 			} else {
 				printf(";\n");
 			}

--- a/oc/compiler/symtab/symtab.c
+++ b/oc/compiler/symtab/symtab.c
@@ -1072,7 +1072,7 @@ void print_variable_name(symtab_variable_record_t* record){
 			
 			//We'll print out some abbreviated stuff with the let record
 			if(record->declare_or_let == 1){
-				printf(" = <initializer>;\n\n");
+				printf("= <initializer>;\n\n");
 			} else {
 				printf(";\n");
 			}

--- a/oc/test_files/address_op.ol
+++ b/oc/test_files/address_op.ol
@@ -4,11 +4,11 @@
 */
 
 pub fn main() -> i32 {
-	let mut x:u32 := 3;
-	let mut y:u32* := &x;
-	let mut z:u32** := &y;
+	let mut x:u32 = 3;
+	let mut y:u32* = &x;
+	let mut z:u32** = &y;
 
-	x := 127;
+	x = 127;
 
 	ret **z;
 }

--- a/oc/test_files/address_op_optimizer.ol
+++ b/oc/test_files/address_op_optimizer.ol
@@ -4,16 +4,16 @@
 */
 
 pub fn main(argc:i32, argv:char**) -> i32 {
-	let mut x:u32 := 3;
+	let mut x:u32 = 3;
 
 	//Should be irrelevant
 	x <<= 3;
-	x := 23;
+	x = 23;
 
 	//But everything after here should be relevant
-	let mut y:u32* := &x;
+	let mut y:u32* = &x;
 
-	x := 32;
+	x = 32;
 	x /= argc;
 
 	ret *y;

--- a/oc/test_files/array_access_deref.ol
+++ b/oc/test_files/array_access_deref.ol
@@ -4,8 +4,8 @@
 */
 
 pub fn access_array(mut a:i32**) -> i32{
-	(*a)[1] := 3;
-	(*a)[2] := 3;
+	(*a)[1] = 3;
+	(*a)[2] = 3;
 
 	ret (*a)[2];
 }
@@ -14,7 +14,7 @@ pub fn access_array(mut a:i32**) -> i32{
 pub fn main() -> i32 {
 	//The compiler should detect and count the number
 	//in the array initializer list.
-	let arr:i32[] := [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+	let arr:i32[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
 	ret arr[3];
 }

--- a/oc/test_files/array_in_struct_intializer.ol
+++ b/oc/test_files/array_in_struct_intializer.ol
@@ -21,7 +21,7 @@ define struct my_struct{
 
 pub fn main(arg:i32, argv:char**) -> i32{
 	//Declare and initialize a struct
-	let a:custom_struct := {'a', [2,3,4], 'b'};
+	let a:custom_struct = {'a', [2,3,4], 'b'};
 
 	//Grab the value from the internal array argument
 	ret a:y[arg];

--- a/oc/test_files/array_in_union.ol
+++ b/oc/test_files/array_in_union.ol
@@ -15,7 +15,7 @@ pub fn main() -> i32{
 	declare my_union:custom_union;
 	
 	//Store x
-	my_union.x[2] := 32;
+	my_union.x[2] = 32;
 	
 	//Read as char
 	ret my_union.ch + my_union.x[3];

--- a/oc/test_files/array_initializer.ol
+++ b/oc/test_files/array_initializer.ol
@@ -6,7 +6,7 @@
 pub fn main() -> i32 {
 	//The compiler should detect and count the number
 	//in the array initializer list.
-	let arr:i32[] := [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+	let arr:i32[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
 	ret arr[3];
 }

--- a/oc/test_files/array_initializer_2d.ol
+++ b/oc/test_files/array_initializer_2d.ol
@@ -5,7 +5,7 @@
 
 pub fn main() -> i32 {
 	//Validate that we're able to do a 2d array initializer
-	let arr:i32[][] := [[1,2,3],[3,4,5],[6,7,8]];
+	let arr:i32[][] = [[1,2,3],[3,4,5],[6,7,8]];
 
 	ret arr[0][1];
 }

--- a/oc/test_files/array_initializer_invalid_length.ol
+++ b/oc/test_files/array_initializer_invalid_length.ol
@@ -5,7 +5,7 @@
 
 pub fn main() -> i32 {
 	//Should fail - length is invalid
-	let mut arr:i32[2] := [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+	let mut arr:i32[2] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
 	ret arr[3];
 }

--- a/oc/test_files/array_of_function_pointers.ol
+++ b/oc/test_files/array_of_function_pointers.ol
@@ -30,11 +30,11 @@ pub fn main() -> i32{
 
 	declare mut functions:arithmetic_function[3];
 
-	functions[0] := add;
-	functions[1] := subtract;
-	functions[2] := multiply;
+	functions[0] = add;
+	functions[1] = subtract;
+	functions[2] = multiply;
 
-	let x:arithmetic_function := functions[2];
+	let x:arithmetic_function = functions[2];
 
 	ret @x(1, 3);
 }

--- a/oc/test_files/array_of_structs.ol
+++ b/oc/test_files/array_of_structs.ol
@@ -13,8 +13,8 @@ pub fn main(arg:i32, argv:char**) -> i32{
 	//Declare an array of such items
 	declare mut structure_arr:my_struct[32];
 
-	structure_arr[2]:y := 23;
-	structure_arr[2]:ch := 'a';
+	structure_arr[2]:y = 23;
+	structure_arr[2]:ch = 'a';
 
 	ret structure_arr[3]:y;
 }

--- a/oc/test_files/array_of_structs_initializer.ol
+++ b/oc/test_files/array_of_structs_initializer.ol
@@ -14,7 +14,7 @@ pub fn main(arg:i32, argv:char**) -> i32{
 	//Declare an array of such items
 
 	//Declare the struct array
-	let structure_arr:my_struct[] := [{'a', 'b', 23}, {'b', 'a', 22}, {'a', 'b', 222}];
+	let structure_arr:my_struct[] = [{'a', 'b', 23}, {'b', 'a', 22}, {'a', 'b', 222}];
 
 	//grab the structure array at the argument at y
 	ret structure_arr[arg]:y;

--- a/oc/test_files/array_of_unions.ol
+++ b/oc/test_files/array_of_unions.ol
@@ -12,8 +12,8 @@ pub fn main(arg:i32, argv:char**) -> i32{
 	//Declare an array of such items
 	declare mut union_array:my_union[32];
 
-	union_array[2].y := 23;
-	union_array[2].ch := 'a';
+	union_array[2].y = 23;
+	union_array[2].ch = 'a';
 
 	ret union_array[3].y;
 }

--- a/oc/test_files/array_optimizer.ol
+++ b/oc/test_files/array_optimizer.ol
@@ -11,7 +11,7 @@ pub fn array_call(arr:i32*) -> i32{
 pub fn main() -> i32 {
 	//The compiler should detect and count the number
 	//in the array initializer list.
-	let mut arr:i32[] := [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+	let mut arr:i32[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
 	//Make the call
 	ret @array_call(arr);

--- a/oc/test_files/array_testing.ol
+++ b/oc/test_files/array_testing.ol
@@ -8,25 +8,25 @@ pub fn main(mut arg:i32, argv:char**) -> i32{
 	declare mut oneD:i64[2];
 	declare mut oneDi32:i32[2];
 	
-	arr[3][1] := 3;
-	arr[5][arg] := 3;
-	arr[7][0] := 2;
-	arr[arg][3] := 2;
+	arr[3][1] = 3;
+	arr[5][arg] = 3;
+	arr[7][0] = 2;
+	arr[arg][3] = 2;
 
-	oneDi32[1] := 3;
+	oneDi32[1] = 3;
 
-	let mut x:i32 := 33;
-	x := arr[arg][13];
+	let mut x:i32 = 33;
+	x = arr[arg][13];
 
-	let mut i:i32 := 3;
-	//let mut j:i32* := arr;
-	//j := j + 1;
-	arr[i][2] := 333;
+	let mut i:i32 = 3;
+	//let mut j:i32* = arr;
+	//j = j + 1;
+	arr[i][2] = 333;
 	
 	if(arg == 2) {
-		arr[x][i] := arr[2][x];
+		arr[x][i] = arr[2][x];
 	} else {
-		i := arr[0][0];
+		i = arr[0][0];
 	}
 
 

--- a/oc/test_files/bad_combined_default.ol
+++ b/oc/test_files/bad_combined_default.ol
@@ -5,8 +5,8 @@
 
 
 pub fn main(argc:i32, argv:char**) -> i32 {
-	let mut x:i32 := 3;
-	let mut y:i32 := 5;
+	let mut x:i32 = 3;
+	let mut y:i32 = 5;
 
 	switch (argc) {
 		case 1 -> {
@@ -18,7 +18,7 @@ pub fn main(argc:i32, argv:char**) -> i32 {
 		}
 
 		case 7 -> {
-			x := y;
+			x = y;
 		}
 
 		//Invalid, we can't mix the two

--- a/oc/test_files/bad_combined_switch.ol
+++ b/oc/test_files/bad_combined_switch.ol
@@ -5,8 +5,8 @@
 
 
 pub fn main(argc:i32, argv:char**) -> i32 {
-	let mut x:i32 := 3;
-	let mut y:i32 := 5;
+	let mut x:i32 = 3;
+	let mut y:i32 = 5;
 
 	switch (argc) {
 		case 1 -> {
@@ -19,7 +19,7 @@ pub fn main(argc:i32, argv:char**) -> i32 {
 
 		//Invalid, we can't mix the two
 		case 7:
-			x := y;
+			x = y;
 			break;
 	
 

--- a/oc/test_files/bad_enum_mixing.ol
+++ b/oc/test_files/bad_enum_mixing.ol
@@ -12,26 +12,26 @@ define enum my_enum {
 } as custom_enum;
 
 fn tester(mut param:custom_enum) -> i32{
-	let mut x:i32 := 32;
+	let mut x:i32 = 32;
 
 	switch(param){
 		case A -> {
-			x := 32;
+			x = 32;
 		}
 		case B -> {
-			x := -3;
+			x = -3;
 		}
 		case C -> {}
 		case D -> {
-			x := 211;
+			x = 211;
 		}
 
 		case E -> {
-			x := 22;
+			x = 22;
 		}
 
 		default -> {
-			x := x - 22;
+			x = x - 22;
 		}
 	}
 

--- a/oc/test_files/bad_nested_defer.ol
+++ b/oc/test_files/bad_nested_defer.ol
@@ -4,9 +4,9 @@
 */
 
 pub fn main() -> i32 {
-	let mut x:i32 := 0;
-	let mut y:i32 := 0;
-	let mut z:i32 := 0;
+	let mut x:i32 = 0;
+	let mut y:i32 = 0;
+	let mut z:i32 = 0;
 
 	while ( x <= 3) {
 		x++;
@@ -26,7 +26,7 @@ pub fn main() -> i32 {
 	} while ( x < 3);
 
 	//For loop
-	for(let mut i:i32 := 0; i < 89; i++) {
+	for(let mut i:i32 = 0; i < 89; i++) {
 		x++;
 
 		defer {

--- a/oc/test_files/bad_void_declaration.ol
+++ b/oc/test_files/bad_void_declaration.ol
@@ -5,26 +5,26 @@
 
 
 pub fn main(void, argc:i32, argv:char**) -> i32{
-	let mut x:i32 := 32;
+	let mut x:i32 = 32;
 
 	switch(x){
 		case 2 -> {
-			x := 32;
+			x = 32;
 		}
 		case 1 -> {
-			x := -3;
+			x = -3;
 		}
 		case 4 -> {}
 		case 3 -> {
-			x := 211;
+			x = 211;
 		}
 
 		case 6 -> {
-			x := 22;
+			x = 22;
 		}
 
 		default -> {
-			x := x - 22;
+			x = x - 22;
 		}
 	}
 
@@ -33,10 +33,10 @@ pub fn main(void, argc:i32, argv:char**) -> i32{
 	
 	switch(x){
 		default -> {
-			let i:i32 := 2;
+			let i:i32 = 2;
 		}
 		case 2 -> {
-			let i:i32 := 3;
+			let i:i32 = 3;
 		}
 	}
 	

--- a/oc/test_files/basic_string_handling.ol
+++ b/oc/test_files/basic_string_handling.ol
@@ -14,8 +14,8 @@ fn handling_string(a:char*, b:char*) -> char{
 
 
 pub fn main(argc:i32, argv:char**) -> i32 {
-	let my_string:char* := "Hello";
-	let string_arr:char* := " world";
+	let my_string:char* = "Hello";
+	let string_arr:char* = " world";
 
 	ret @handling_string(my_string, string_arr)
 		+ @handling_string("direct", "strings");

--- a/oc/test_files/basic_union_type.ol
+++ b/oc/test_files/basic_union_type.ol
@@ -14,7 +14,7 @@ pub fn main() -> i32{
 	declare my_union:custom_union;
 	
 	//Store x
-	my_union.x := 32;
+	my_union.x = 32;
 	
 	//Read as char
 	ret my_union.ch;

--- a/oc/test_files/binary_operation_ternaries.ol
+++ b/oc/test_files/binary_operation_ternaries.ol
@@ -4,12 +4,12 @@
 */
 
 pub fn main() -> i32 {
-	let mut x:i32 := 3;
-	let mut y:i32 := 4;
-	let mut z:i32 := 5;
-	let mut a:i32 := 6;
+	let mut x:i32 = 3;
+	let mut y:i32 = 4;
+	let mut z:i32 = 5;
+	let mut a:i32 = 6;
 
-	let ret_val:i32 := (x == 2 ? x else y) + (y == 3 ? z else a);
+	let ret_val:i32 = (x == 2 ? x else y) + (y == 3 ? z else a);
 
 	ret ret_val;
 }

--- a/oc/test_files/break_in_defer.ol
+++ b/oc/test_files/break_in_defer.ol
@@ -4,15 +4,15 @@
 */
 
 pub fn main() -> i32 {
-	let mut x:i32 := 3;
-	let mut y:i32 := 3;
+	let mut x:i32 = 3;
+	let mut y:i32 = 3;
 
 	//valid
 	defer {
 		y++;
 	}
 
-	y := y - 11;
+	y = y - 11;
 
 	defer {
 		x -= 32;

--- a/oc/test_files/break_in_function.ol
+++ b/oc/test_files/break_in_function.ol
@@ -4,15 +4,15 @@
 */
 
 pub fn main() -> i32 {
-	let mut x:i32 := 3;
-	let mut y:i32 := 3;
+	let mut x:i32 = 3;
+	let mut y:i32 = 3;
 
 	//valid
 	defer {
 		y++;
 	}
 
-	y := y - 11;
+	y = y - 11;
 
 	defer {
 		x -= 32;

--- a/oc/test_files/break_in_if.ol
+++ b/oc/test_files/break_in_if.ol
@@ -4,15 +4,15 @@
 */
 
 pub fn main() -> i32 {
-	let mut x:i32 := 3;
-	let mut y:i32 := 3;
+	let mut x:i32 = 3;
+	let mut y:i32 = 3;
 
 	//valid
 	defer {
 		y++;
 	}
 
-	y := y - 11;
+	y = y - 11;
 
 	defer {
 		x -= 32;

--- a/oc/test_files/c_switch_nested_in_switch.ol
+++ b/oc/test_files/c_switch_nested_in_switch.ol
@@ -6,8 +6,8 @@
 
 
 pub fn main(argc:i32, argv:char**) -> i32 {
-	let mut x:i32 := 3;
-	let mut y:i32 := 5;
+	let mut x:i32 = 3;
+	let mut y:i32 = 5;
 
 	switch (argc) {
 		case 1 -> {

--- a/oc/test_files/caller_saving.ol
+++ b/oc/test_files/caller_saving.ol
@@ -4,7 +4,7 @@
 */
 
 fn pcount_r(mut x:u64) -> u64 {
-	let mut y:u64 := 32;
+	let mut y:u64 = 32;
 	if( x == 0) {
 		ret (x & 1) + @pcount_r(x >> 1) + y;
 	} else if (x == 1) {
@@ -12,7 +12,7 @@ fn pcount_r(mut x:u64) -> u64 {
 			ret 1 + y;
 		}
 
-		x := x + 1;
+		x = x + 1;
 	} else {
 		ret 0;
 	}

--- a/oc/test_files/case_statements.ol
+++ b/oc/test_files/case_statements.ol
@@ -3,26 +3,26 @@
 */
 
 pub fn main(arg:i32, argv:char**) -> i32{
-	let mut x:i32 := 32;
+	let mut x:i32 = 32;
 
 	switch(x){
 		case 2 -> {
-			x := 32;
+			x = 32;
 		}
 		case 1 -> {
-			x := -3;
+			x = -3;
 		}
 		case 4 -> {}
 		case 3 -> {
-			x := 211;
+			x = 211;
 		}
 
 		case 6 -> {
-			x := 22;
+			x = 22;
 		}
 
 		default -> {
-			x := x - 22;
+			x = x - 22;
 		}
 	}
 
@@ -31,10 +31,10 @@ pub fn main(arg:i32, argv:char**) -> i32{
 	
 	switch(x){
 		default -> {
-			let i:i32 := 2;
+			let i:i32 = 2;
 		}
 		case 2 -> {
-			let i:i32 := 3;
+			let i:i32 = 3;
 		}
 	}
 	

--- a/oc/test_files/comparison_testing.ol
+++ b/oc/test_files/comparison_testing.ol
@@ -4,8 +4,8 @@
 */
 
 pub fn main() -> i32 {
-	let i:u32 := 2;
-	let j:i32 := 3;
+	let i:u32 = 2;
+	let j:i32 = 3;
 
 	ret j < i;
 }

--- a/oc/test_files/complex_structure_testing.ol
+++ b/oc/test_files/complex_structure_testing.ol
@@ -16,11 +16,11 @@ pub fn main(arg:i32, argv:char**) -> i32{
 
 	declare mut structure:my_struct;
 
-	structure:ch := 'a';
-	structure:x[3] := 3;
-	structure:x[5] := 2;
-	structure:lch := 'b';
-	structure:y := 5;
+	structure:ch = 'a';
+	structure:x[3] = 3;
+	structure:x[5] = 2;
+	structure:lch = 'b';
+	structure:y = 5;
 
 	//So it isn't optimized away
 	ret structure:x[2];

--- a/oc/test_files/compressed_equality_bad.ol
+++ b/oc/test_files/compressed_equality_bad.ol
@@ -3,8 +3,8 @@
 */
 
 fn bad_type() -> i32 {
-	let mut x:i32 := 3;
-	let mut y:i8 := 2;
+	let mut x:i32 = 3;
+	let mut y:i8 = 2;
 
 	//bad size
 	y += 3;
@@ -13,9 +13,9 @@ fn bad_type() -> i32 {
 }
 
 fn invalid_op_type_mod() -> i32 {
-	let mut x:i32 := 3;
-	let mut z:i32 := 32;
-	let mut y:i32* := &x;
+	let mut x:i32 = 3;
+	let mut z:i32 = 32;
+	let mut y:i32* = &x;
 
 	//Pointers cannot be modded
 	y %= x;
@@ -24,9 +24,9 @@ fn invalid_op_type_mod() -> i32 {
 }
 
 fn invalid_op_divide() -> i32 {
-	let mut x:i32 := 3;
-	let mut z:i32 := 32;
-	let mut y:i32* := &x;
+	let mut x:i32 = 3;
+	let mut z:i32 = 32;
+	let mut y:i32* = &x;
 
 	//Pointers cannot be divided 
 	y /= x;
@@ -35,9 +35,9 @@ fn invalid_op_divide() -> i32 {
 }
 
 fn invalid_op_shift() -> i32 {
-	let mut x:i32 := 3;
-	let mut z:i32 := 32;
-	let mut y:i32* := &x;
+	let mut x:i32 = 3;
+	let mut z:i32 = 32;
+	let mut y:i32* = &x;
 
 	//Pointers cannot be shifted 
 	y <<= x;
@@ -47,9 +47,9 @@ fn invalid_op_shift() -> i32 {
 
 
 fn invalid_op_type() -> i32 {
-	let mut x:i32 := 3;
-	let mut z:i32 := 32;
-	let mut y:i32* := &x;
+	let mut x:i32 = 3;
+	let mut z:i32 = 32;
+	let mut y:i32* = &x;
 
 	//Pointers cannot be multiplied
 	y *= x;
@@ -58,8 +58,8 @@ fn invalid_op_type() -> i32 {
 }
 
 fn bad_size() -> i32 {
-	let mut x:i32 := 3;
-	let mut y:i64 := 222;
+	let mut x:i32 = 3;
+	let mut y:i64 = 222;
 
 	//bad size
 	x *= y;

--- a/oc/test_files/compressed_equality_test.ol
+++ b/oc/test_files/compressed_equality_test.ol
@@ -4,21 +4,21 @@
 */
 
 fn test_unsigned_value() -> i32 {
-	let mut x:i32 := 2;
-	let mut y:u32 := 3;
+	let mut x:i32 = 2;
+	let mut y:u32 = 3;
 
 	//Should trigger an unsigned multiplication
 	//BUG here
 	x *= y;
-	x := x * y;
+	x = x * y;
 
 	ret x;
 }
 
 fn test_pointer_addition() -> i32 {
-	let mut x:i32 := 3;
-	let mut z:i32 := 5;
-	let mut y:i32* := &x;
+	let mut x:i32 = 3;
+	let mut z:i32 = 5;
+	let mut y:i32* = &x;
 
 	y += z;
 
@@ -27,9 +27,9 @@ fn test_pointer_addition() -> i32 {
 
 
 fn test_pointer_subtraction() -> i32 {
-	let mut x:i32 := 3;
-	let mut z:i32 := 5;
-	let mut y:i32* := &x;
+	let mut x:i32 = 3;
+	let mut z:i32 = 5;
+	let mut y:i32* = &x;
 
 	y -= z;
 
@@ -38,71 +38,71 @@ fn test_pointer_subtraction() -> i32 {
 
 
 fn test_plus() -> i32 {
-	let mut x:i32 := 2;
-	let mut y:i32 := -3;
+	let mut x:i32 = 2;
+	let mut y:i32 = -3;
 	y += x;
 	ret y;
 }
 
 fn test_minus() -> i32 {
-	let mut x:i32 := 2;
-	let mut y:i32 := -3;
+	let mut x:i32 = 2;
+	let mut y:i32 = -3;
 	y -= x;
 	ret y;
 }
 
 fn test_times() -> i32 {
-	let mut x:i32 := 2;
-	let mut y:i32 := -3;
+	let mut x:i32 = 2;
+	let mut y:i32 = -3;
 	y *= x;
 	ret y;
 }
 
 fn test_divide() -> i32 {
-	let mut x:i32 := 2;
-	let mut y:i32 := -3;
+	let mut x:i32 = 2;
+	let mut y:i32 = -3;
 	y /= x;
 	ret y;
 }
 
 fn test_mod() -> i32 {
-	let mut x:i32 := 2;
-	let mut y:i32 := -3;
+	let mut x:i32 = 2;
+	let mut y:i32 = -3;
 	y %= x;
 	ret y;
 }
 
 fn test_xor() -> i32 {
-	let mut x:i32 := 2;
-	let mut y:i32 := -3;
+	let mut x:i32 = 2;
+	let mut y:i32 = -3;
 	y ^= x;
 	ret y;
 }
 
 fn test_and() -> i32 {
-	let mut x:i32 := 2;
-	let mut y:i32 := -3;
+	let mut x:i32 = 2;
+	let mut y:i32 = -3;
 	y &= x;
 	ret y;
 }
 
 fn test_or() -> i32 {
-	let mut x:i32 := 2;
-	let mut y:i32 := -3;
+	let mut x:i32 = 2;
+	let mut y:i32 = -3;
 	y |= x;
 	ret y;
 }
 
 fn test_right_shift() -> i32 {
-	let mut x:i32 := 2;
-	let mut y:i32 := -3;
+	let mut x:i32 = 2;
+	let mut y:i32 = -3;
 	y >>= x;
 	ret y;
 }
 
 fn test_left_shift() -> i32 {
-	let mut x:i32 := 2;
-	let mut y:i32 := -3;
+	let mut x:i32 = 2;
+	let mut y:i32 = -3;
 	y <<= x;
 	ret y;
 }

--- a/oc/test_files/conditional_break.ol
+++ b/oc/test_files/conditional_break.ol
@@ -3,17 +3,17 @@
 */
 
 pub fn main(arg:i32, argv:char**) -> i32{
-	let mut x:i32 := 32;
+	let mut x:i32 = 32;
 
-	let mut _:u32 := 2;
+	let mut _:u32 = 2;
 
 	while (_ < 65) {
-		let mut i:u32 := 2;
+		let mut i:u32 = 2;
 		if(i == 2) {
-			i := 3;
+			i = 3;
 		}
 		break when(x > 33 || x <= 55);
-		x := x * 37;
+		x = x * 37;
 		_++;
 	}
 

--- a/oc/test_files/conditional_jump.ol
+++ b/oc/test_files/conditional_jump.ol
@@ -4,8 +4,8 @@
 */
 
 pub fn main(argc:i32, argv:char**) -> i32 {
-	let mut x:i32 := argc;
-	let mut y:i32 := 2322;
+	let mut x:i32 = argc;
+	let mut y:i32 = 2322;
 
 	//So long as x is more than 0
 	while(1){

--- a/oc/test_files/constant_assignment_testing.ol
+++ b/oc/test_files/constant_assignment_testing.ol
@@ -8,12 +8,12 @@ fn test() -> u32{
 }
 
 pub fn main() -> i32 {
-	let mut a:i32 := 3;
-	let mut b:i16 := 3;
+	let mut a:i32 = 3;
+	let mut b:i16 = 3;
 
-	let mut c:i16 := b + 6;
+	let mut c:i16 = b + 6;
 
-	let mut x:i16 := b + c;
+	let mut x:i16 = b + c;
 
 	ret a + b + c;
 }

--- a/oc/test_files/constant_conditional_check.ol
+++ b/oc/test_files/constant_conditional_check.ol
@@ -4,7 +4,7 @@
 */
 
 pub fn main() -> i32 {
-	let mut x:i32 := 232;
+	let mut x:i32 = 232;
 
 	//Checking while
 	while(1){
@@ -22,7 +22,7 @@ pub fn main() -> i32 {
 	} while(1);
 
 	//checking for
-	for(let mut a:i32 := 32; a; a--){
+	for(let mut a:i32 = 32; a; a--){
 		x--;
 	}
 

--- a/oc/test_files/constant_folding_division.ol
+++ b/oc/test_files/constant_folding_division.ol
@@ -4,31 +4,31 @@
 */
 
 pub fn divide_by_negative() -> i32 {
-	let mut x:i32 := 5;
+	let mut x:i32 = 5;
 	
 	//Should *not* optimize
-	let mut z:i32 := x / -4;
+	let mut z:i32 = x / -4;
 	
 	ret z + x;
 }
 
 pub fn unsigned_shift() -> u32{
-	let mut x:u32 := 3;
-	let mut y:u32 := x - 1;
+	let mut x:u32 = 3;
+	let mut y:u32 = x - 1;
 
 	//This should optimize into a logical left shift
-	let mut z:u32 := y / 4;
+	let mut z:u32 = y / 4;
 
 	ret z + x;
 }
 
 
 pub fn main() -> i32{
-	let mut x:i32 := 3;
-	let mut y:i32 := x - 1;
+	let mut x:i32 = 3;
+	let mut y:i32 = x - 1;
 
 	//This should optimize into an arithmetic right shift
-	let mut z:i32 := y / 4;
+	let mut z:i32 = y / 4;
 
 	ret z + x;
 }

--- a/oc/test_files/constant_folding_multiplication.ol
+++ b/oc/test_files/constant_folding_multiplication.ol
@@ -4,31 +4,31 @@
 */
 
 pub fn multiply_by_negative() -> i32 {
-	let mut x:i32 := 5;
+	let mut x:i32 = 5;
 	
 	//Should *not* optimize
-	let mut z:i32 := x * -4;
+	let mut z:i32 = x * -4;
 	
 	ret z + x;
 }
 
 pub fn unsigned_shift() -> u32{
-	let mut x:u32 := 3;
-	let mut y:u32 := x - 1;
+	let mut x:u32 = 3;
+	let mut y:u32 = x - 1;
 
 	//This should optimize into a logical right shift
-	let mut z:u32 := y * 4;
+	let mut z:u32 = y * 4;
 
 	ret z + x;
 }
 
 
 pub fn main() -> i32{
-	let mut x:i32 := 3;
-	let mut y:i32 := x - 1;
+	let mut x:i32 = 3;
+	let mut y:i32 = x - 1;
 
 	//This should optimize into an arithmetic right shift
-	let mut z:i32 := y * 4;
+	let mut z:i32 = y * 4;
 
 	ret z + x;
 }

--- a/oc/test_files/constant_folding_shifting.ol
+++ b/oc/test_files/constant_folding_shifting.ol
@@ -4,14 +4,14 @@
 */
 
 pub fn main() -> i32{
-	let mut x:i32 := 3;
-	let mut y:i32 := x - 1;
+	let mut x:i32 = 3;
+	let mut y:i32 = x - 1;
 
 	//Should just become an assignment
-	let mut z:i32 := y >> 0;
+	let mut z:i32 = y >> 0;
 	
 	//Should also be an assignment
-	x := z << 0;
+	x = z << 0;
 
 	ret z + x;
 }

--- a/oc/test_files/construct_pointer_access.ol
+++ b/oc/test_files/construct_pointer_access.ol
@@ -14,7 +14,7 @@ fn construct_pointer_arrays(arg:i32) -> i64 {
 	//An array of structure pointers
 	declare mut arr:my_struct*[232];
 
-	arr[2]=>x := 32;
+	arr[2]=>x = 32;
 
 }
 
@@ -23,26 +23,26 @@ fn not_main(arg:i32, argv:char**) -> i64 {
 	//Stack allocate a structure
 	declare mut structure:my_struct;
 	//Take it's address
-	let mut struct_ptr:my_struct* := &structure;
+	let mut struct_ptr:my_struct* = &structure;
 
-	struct_ptr=>ch := 'a';
-	struct_ptr=>x := 3;
-	struct_ptr=>lch := 'b';
-	struct_ptr=>y := 5;
+	struct_ptr=>ch = 'a';
+	struct_ptr=>x = 3;
+	struct_ptr=>lch = 'b';
+	struct_ptr=>y = 5;
 
 	if(arg == 0) {
-		struct_ptr=>x := 2;
-		struct_ptr=>y := 1;
-		struct_ptr=>lch := 'c';
+		struct_ptr=>x = 2;
+		struct_ptr=>y = 1;
+		struct_ptr=>lch = 'c';
 	} else{
-		struct_ptr=>y := 5;
+		struct_ptr=>y = 5;
 	}
 
 	//Useless assign
-	let mut z:i64 := struct_ptr=>x;
+	let mut z:i64 = struct_ptr=>x;
 
-	//structure:x := 7;
-	let x:i64 := struct_ptr=>x;
+	//structure:x = 7;
+	let x:i64 = struct_ptr=>x;
 
 	//So it isn't optimized away
 	ret x;

--- a/oc/test_files/construct_testing.ol
+++ b/oc/test_files/construct_testing.ol
@@ -13,24 +13,24 @@ fn not_main(arg:i32, argv:char**) -> i64 {
 
 	declare mut structure:my_struct;
 
-	structure:ch := 'a';
-	structure:x := 3;
-	structure:lch := 'b';
-	structure:y := 5;
+	structure:ch = 'a';
+	structure:x = 3;
+	structure:lch = 'b';
+	structure:y = 5;
 
 	if(arg == 0) {
-		structure:x := 2;
-		structure:y := 1;
-		structure:lch := 'c';
+		structure:x = 2;
+		structure:y = 1;
+		structure:lch = 'c';
 	} else{
-		structure:y := 5;
+		structure:y = 5;
 	}
 
 	//Useless assign
-	let mut z:i64 := structure:x;
+	let mut z:i64 = structure:x;
 
-	//structure:x := 7;
-	let x:i64 := structure:x;
+	//structure:x = 7;
+	let x:i64 = structure:x;
 
 	//So it isn't optimized away
 	ret x;

--- a/oc/test_files/continue_in_defer.ol
+++ b/oc/test_files/continue_in_defer.ol
@@ -4,15 +4,15 @@
 */
 
 pub fn main() -> i32 {
-	let mut x:i32 := 3;
-	let mut y:i32 := 3;
+	let mut x:i32 = 3;
+	let mut y:i32 = 3;
 
 	//valid
 	defer {
 		y++;
 	}
 
-	y := y - 11;
+	y = y - 11;
 
 	defer {
 		x -= 32;

--- a/oc/test_files/continue_in_function.ol
+++ b/oc/test_files/continue_in_function.ol
@@ -4,15 +4,15 @@
 */
 
 pub fn main() -> i32 {
-	let mut x:i32 := 3;
-	let mut y:i32 := 3;
+	let mut x:i32 = 3;
+	let mut y:i32 = 3;
 
 	//valid
 	defer {
 		y++;
 	}
 
-	y := y - 11;
+	y = y - 11;
 
 	defer {
 		x -= 32;

--- a/oc/test_files/continue_in_if.ol
+++ b/oc/test_files/continue_in_if.ol
@@ -4,15 +4,15 @@
 */
 
 pub fn main() -> i32 {
-	let mut x:i32 := 3;
-	let mut y:i32 := 3;
+	let mut x:i32 = 3;
+	let mut y:i32 = 3;
 
 	//valid
 	defer {
 		y++;
 	}
 
-	y := y - 11;
+	y = y - 11;
 
 	defer {
 		x -= 32;

--- a/oc/test_files/data_area_test_input.ol
+++ b/oc/test_files/data_area_test_input.ol
@@ -18,44 +18,44 @@ pub fn main(mut arg:i32, argv:char**) -> i32{
 
 	declare mut structure:my_struct;
 
-	structure:ch := 'a';
-	structure:x := 3;
-	structure:lch := 'b';
-	structure:y := 5;
+	structure:ch = 'a';
+	structure:x = 3;
+	structure:lch = 'b';
+	structure:y = 5;
 
 	if(arg == 0) {
-		structure:x := 2;
-		structure:y := 1;
-		structure:lch := 'c';
+		structure:x = 2;
+		structure:y = 1;
+		structure:lch = 'c';
 	} else{
-		structure:y := 5;
+		structure:y = 5;
 	}
 
 	//Useless assign
-	let mut z:i64 := structure:x;
+	let mut z:i64 = structure:x;
 
-	//structure:x := 7;
-	let x:i64 := structure:x;
+	//structure:x = 7;
+	let x:i64 = structure:x;
 
-	arr[3][1] := 3;
-	arr[5][arg] := 3;
-	arr[7][0] := 2;
-	arr[arg][3] := 2;
+	arr[3][1] = 3;
+	arr[5][arg] = 3;
+	arr[7][0] = 2;
+	arr[arg][3] = 2;
 
-	oneDi32[1] := 3;
+	oneDi32[1] = 3;
 
-	let mut x:i32 := 33;
-	x := arr[arg][13];
+	let mut x:i32 = 33;
+	x = arr[arg][13];
 
-	let mut i:i32 := 3;
-	//let mut j:i32* := arr;
-	//j := j + 1;
-	arr[i][2] := 333;
+	let mut i:i32 = 3;
+	//let mut j:i32* = arr;
+	//j = j + 1;
+	arr[i][2] = 333;
 	
 	if(arg == 2) {
-		arr[x][i] := arr[2][x];
+		arr[x][i] = arr[2][x];
 	} else {
-		i := arr[0][0];
+		i = arr[0][0];
 	}
 
 	//So it isn't optimized away

--- a/oc/test_files/defer_in_defer_test.ol
+++ b/oc/test_files/defer_in_defer_test.ol
@@ -4,15 +4,15 @@
 */
 
 pub fn main() -> i32 {
-	let mut x:i32 := 3;
-	let mut y:i32 := 3;
+	let mut x:i32 = 3;
+	let mut y:i32 = 3;
 
 	//valid
 	defer {
 		y++;
 	}
 
-	y := y - 11;
+	y = y - 11;
 
 	defer {
 		defer {

--- a/oc/test_files/direct_jump.ol
+++ b/oc/test_files/direct_jump.ol
@@ -4,8 +4,8 @@
 */
 
 pub fn main(argc:i32, argv:char**) -> i32 {
-	let mut x:i32 := argc;
-	let mut y:i32 := 2322;
+	let mut x:i32 = argc;
+	let mut y:i32 = 2322;
 
 	//So long as x is more than 0
 	while(x < 32){

--- a/oc/test_files/div_test.ol
+++ b/oc/test_files/div_test.ol
@@ -1,9 +1,9 @@
 pub fn main() -> i32{
-	let mut x:i32 := 3;
-	let mut y:i32 := x - 1;
+	let mut x:i32 = 3;
+	let mut y:i32 = x - 1;
 
-	let mut z:i32 := y / x;
-	let mut k:i32 := y * sizeof(x);
+	let mut z:i32 = y / x;
+	let mut k:i32 = y * sizeof(x);
 
 	ret z + k * typesize(f64);
 }

--- a/oc/test_files/double_default.ol
+++ b/oc/test_files/double_default.ol
@@ -5,12 +5,12 @@
 
 
 pub fn main(argc:i32, argv:char**) -> i32 {
-	let mut x:i32 := 3;
-	let mut y:i32 := 5;
+	let mut x:i32 = 3;
+	let mut y:i32 = 5;
 
 	switch (argc) {
 		default -> {
-			x := y * 2;
+			x = y * 2;
 		}
 
 		case 1 -> {

--- a/oc/test_files/double_pointer_struct.ol
+++ b/oc/test_files/double_pointer_struct.ol
@@ -18,7 +18,7 @@ define struct my_struct{
 * Test reassigning a double pointer
 */
 pub fn double_pointer_reassign(mut ptr:i64**) -> i64**{
-	**ptr := 32;
+	**ptr = 32;
 
 	ret ptr;
 }
@@ -27,7 +27,7 @@ pub fn double_pointer_reassign(mut ptr:i64**) -> i64**{
 * Test reassigning a double pointer
 */
 pub fn single_pointer_reassign(mut ptr:i64*) -> void{
-	*ptr := 32;
+	*ptr = 32;
 
 	ret;
 }
@@ -39,8 +39,8 @@ pub fn single_pointer_reassign(mut ptr:i64*) -> void{
 * A function that will mutate a structure in its entirety
 */
 pub fn mutate_structure_pointer(mut struct_pointer:custom_struct**) -> i32 {
-	(*struct_pointer)=>y[2] := 32;
-	(*struct_pointer)=>lch := 'a';
+	(*struct_pointer)=>y[2] = 32;
+	(*struct_pointer)=>lch = 'a';
 
 	ret 0;
 }
@@ -48,13 +48,13 @@ pub fn mutate_structure_pointer(mut struct_pointer:custom_struct**) -> i32 {
 
 pub fn main(arg:i32, argv:char**) -> i32{
 	//Declare and initialize a struct
-	let mut a:custom_struct := {'a', [2,3,4], 'b'};
+	let mut a:custom_struct = {'a', [2,3,4], 'b'};
 	
 	//One more pointer
-	let mut b:custom_struct* := &a;
+	let mut b:custom_struct* = &a;
 
-	let mut x:i64 := 32;
-	let mut ptr:i64* := &x;
+	let mut x:i64 = 32;
+	let mut ptr:i64* = &x;
 
 	@double_pointer_reassign(&ptr);
 

--- a/oc/test_files/enum_forced_to_u16.ol
+++ b/oc/test_files/enum_forced_to_u16.ol
@@ -12,26 +12,26 @@ define enum my_enum {
 } as custom_enum;
 
 fn tester(mut param:custom_enum) -> i32{
-	let mut x:i32 := 32;
+	let mut x:i32 = 32;
 
 	switch(param){
 		case A -> {
-			x := 32;
+			x = 32;
 		}
 		case B -> {
-			x := -3;
+			x = -3;
 		}
 		case C -> {}
 		case D -> {
-			x := 211;
+			x = 211;
 		}
 
 		case E -> {
-			x := 22;
+			x = 22;
 		}
 
 		default -> {
-			x := x - 22;
+			x = x - 22;
 		}
 	}
 

--- a/oc/test_files/enum_type_repeated_value.ol
+++ b/oc/test_files/enum_type_repeated_value.ol
@@ -11,26 +11,26 @@ define enum my_enum {
 } as custom_enum;
 
 fn tester(param:custom_enum) -> i32{
-	let mut x:i32 := 32;
+	let mut x:i32 = 32;
 
 	switch(param){
 		case A -> {
-			x := 32;
+			x = 32;
 		}
 		case B -> {
-			x := -3;
+			x = -3;
 		}
 		case C -> {}
 		case D -> {
-			x := 211;
+			x = 211;
 		}
 
 		case 11 -> {
-			x := 22;
+			x = 22;
 		}
 
 		default -> {
-			x := x - 22;
+			x = x - 22;
 		}
 	}
 

--- a/oc/test_files/function_call_bad_type.ol
+++ b/oc/test_files/function_call_bad_type.ol
@@ -10,7 +10,7 @@ fn tester(x:i32, y:i8) -> i32 {
 
 
 pub fn main() -> i32 {
-	let mut x:i32 := 6;
+	let mut x:i32 = 6;
 
 	//Bad type, x is too large
 	ret @tester(3, x);

--- a/oc/test_files/function_pointer_call_bad_type.ol
+++ b/oc/test_files/function_pointer_call_bad_type.ol
@@ -14,9 +14,9 @@ pub fn main() -> i32 {
 	define fn(i32, i8) -> i32 as test_func;
 
 	//This one is tester
-	let my_func:test_func := tester;
+	let my_func:test_func = tester;
 
-	let mut x:i32 := 6;
+	let mut x:i32 = 6;
 
 	//Bad type, x is too large
 	ret @my_func(3, x);

--- a/oc/test_files/function_pointer_call_too_few_params.ol
+++ b/oc/test_files/function_pointer_call_too_few_params.ol
@@ -13,7 +13,7 @@ pub fn main() -> i32 {
 	define fn(i32, i32) -> i32 as test_func;
 
 	//This one is tester
-	let my_func:test_func := tester;
+	let my_func:test_func = tester;
 
 	//Too few parameters
 	ret @my_func(3);

--- a/oc/test_files/function_pointer_call_too_many_params.ol
+++ b/oc/test_files/function_pointer_call_too_many_params.ol
@@ -13,7 +13,7 @@ pub fn main() -> i32 {
 	define fn(i32, i32) -> i32 as test_func;
 
 	//This one is tester
-	let my_func:test_func := tester;
+	let my_func:test_func = tester;
 
 	//Too many parameters
 	ret @my_func(3, 4, 5);

--- a/oc/test_files/function_pointers.ol
+++ b/oc/test_files/function_pointers.ol
@@ -23,7 +23,7 @@ pub fn main() -> i32 {
 	define fn(mut i32, i32) -> i32 as arithmetic_function;
 
 	//This is the add function
-	let mut x:arithmetic_function := add;
+	let mut x:arithmetic_function = add;
 
 	//Should call add on 1 and 3
 	ret @x(1, 3);

--- a/oc/test_files/function_pointers2.ol
+++ b/oc/test_files/function_pointers2.ol
@@ -23,11 +23,11 @@ pub fn main() -> i32 {
 	define fn(mut i32, i32) -> i32 as arithmetic_function;
 
 	//This is the add function
-	let mut x:arithmetic_function := add;
-	let mut y:arithmetic_function := subtract;
+	let mut x:arithmetic_function = add;
+	let mut y:arithmetic_function = subtract;
 
 	//A more complex example
-	let mut a:i32 := @x(1, 3) + @y(2, 7);
+	let mut a:i32 = @x(1, 3) + @y(2, 7);
 	
 	ret a;
 }

--- a/oc/test_files/if_assignment.ol
+++ b/oc/test_files/if_assignment.ol
@@ -7,9 +7,9 @@ pub fn main(argc:i32, argv:char**) -> i32{
 	declare mut x:i32;
 
 	if(argc == 3) {
-		x := 2;
+		x = 2;
 	} else {
-		x := 3;
+		x = 3;
 	}
 
 	ret x;

--- a/oc/test_files/indexing_string_constants.ol
+++ b/oc/test_files/indexing_string_constants.ol
@@ -6,7 +6,7 @@
 alias char* as string;
 
 pub fn main() -> i32 {
-	let my_str:string := "Hello world";
+	let my_str:string = "Hello world";
 
 	ret my_str[2] + my_str[3];
 }

--- a/oc/test_files/indirect_caller_saving.ol
+++ b/oc/test_files/indirect_caller_saving.ol
@@ -10,7 +10,7 @@
 define fn(mut u32) -> u32 as count_function;
 
 fn pcount_r(mut x:u32) -> u32 {
-	let mut y:u32 := 32;
+	let mut y:u32 = 32;
 	if( x == 0) {
 		ret (x & 1) + @pcount_r(x >> 1) + y;
 	} else if (x == 1) {
@@ -18,7 +18,7 @@ fn pcount_r(mut x:u32) -> u32 {
 			ret 1 + y;
 		}
 
-		x := x + 1;
+		x = x + 1;
 	} else {
 		ret 0;
 	}
@@ -27,14 +27,14 @@ fn pcount_r(mut x:u32) -> u32 {
 }
 
 fn lcount_r(mut x:u32) -> u32 {
-	let mut y:u32 := 32;
+	let mut y:u32 = 32;
 	if( x == 0) {
 		ret (x & 3) + @pcount_r(x >> 5) + y;
 	} else if (x == 5) {
 		if(x > 3) {
 			ret 1 + y;
 		}
-		x := x + 1;
+		x = x + 1;
 	} else {
 		ret 3;
 	}
@@ -45,18 +45,18 @@ fn lcount_r(mut x:u32) -> u32 {
 
 pub fn main(argc:i32, argv:char**) -> i32 {
 	declare mut a:u32;
-	let mut x:u32 := 433;
+	let mut x:u32 = 433;
 
-	a := (x * -128) + (x - 11);
-	x := x / 9;
-	x := x && 21;
-	x := x || 32;
-	x := a - 3 + x;
-	x := x && 21;
+	a = (x * -128) + (x - 11);
+	x = x / 9;
+	x = x && 21;
+	x = x || 32;
+	x = a - 3 + x;
+	x = x && 21;
 
 	//Both defined indirectly
-	let z:count_function := pcount_r;
-	let y:count_function := lcount_r;
+	let z:count_function = pcount_r;
+	let y:count_function = lcount_r;
 
 	ret @z(32) + @z(32) + @y(17) + x;
 }

--- a/oc/test_files/inst_sel_test.ol
+++ b/oc/test_files/inst_sel_test.ol
@@ -3,9 +3,9 @@
 */
 
 fn unsigned_shift() -> u32 {
-	let mut z:u32 := 23;
-	let mut x:u32 := z << 3;
-	let mut y:u32 := z >> x;
+	let mut z:u32 = 23;
+	let mut x:u32 = z << 3;
+	let mut y:u32 = z >> x;
 
 	ret x + y;
 }
@@ -13,26 +13,26 @@ fn unsigned_shift() -> u32 {
 
 pub fn main(arg:i32, argv:char**) -> i32 {
 
-	let mut z:i32 := 33;
-	let mut c:i32 := z - 1;
-	let mut a:i32 := 222;
-	let mut x:i32 := !a;
-	let mut y:i32 := -3;
+	let mut z:i32 = 33;
+	let mut c:i32 = z - 1;
+	let mut a:i32 = 222;
+	let mut x:i32 = !a;
+	let mut y:i32 = -3;
 
-	x := x + y * 8;
-	a := x - 0;
-	x := !a;
+	x = x + y * 8;
+	a = x - 0;
+	x = !a;
 
-	a := (x * -128) + (x - 11);
-	x := x / 9;
-	x := x && 21;
-	x := x || 32;
-	x := a - z + x;
-	x := x && 21;
-	x := x || 32;
-	x := x && 21;
-	x := x || 32;
-	x := c & x;
+	a = (x * -128) + (x - 11);
+	x = x / 9;
+	x = x && 21;
+	x = x || 32;
+	x = a - z + x;
+	x = x && 21;
+	x = x || 32;
+	x = x && 21;
+	x = x || 32;
+	x = c & x;
 
 	ret x + y + a;
 }

--- a/oc/test_files/inst_sel_test2.ol
+++ b/oc/test_files/inst_sel_test2.ol
@@ -3,46 +3,46 @@
 */
 
 fn unsigned_shift() -> u32 {
-	let mut z:u32 := 23;
-	let mut x:u32 := z << 3;
-	let mut y:u32 := z >> 5;
+	let mut z:u32 = 23;
+	let mut x:u32 = z << 3;
+	let mut y:u32 = z >> 5;
 	//Bitwise or
-	y := y | x;
+	y = y | x;
 	//Bitwise xor
-	y := y ^ x;
+	y = y ^ x;
 	//Bitwise and
-	y := y & x;
+	y = y & x;
 
 	ret x + y;
 }
 
 fn modulus() -> u32 {
-	let mut z:u32 := 23;
-	let mut x:u32 := z << 3;
-	let mut y:i32 := z >> 5;
+	let mut z:u32 = 23;
+	let mut x:u32 = z << 3;
+	let mut y:i32 = z >> 5;
 
 	//Modulus
-	y := y % x;
+	y = y % x;
 
 	ret x + y;
 }
 
 
 pub fn main(arg:i32, argv:char**) -> i32 {
-	let mut a:i32 := 3;
-	let mut x:i32 := !a;
-	let mut y:i32 := -3;
+	let mut a:i32 = 3;
+	let mut x:i32 = !a;
+	let mut y:i32 = -3;
 
-	x := x + y * 8;
-	a := x - 0;
-	x := !a;
+	x = x + y * 8;
+	a = x - 0;
+	x = !a;
 	//Modulus
-	x := x % -3;
+	x = x % -3;
 
-	a := (x * -128) + (x - 11);
-	x := x / 8;
-	x := x && 21;
-	x := x || 32;
+	a = (x * -128) + (x - 11);
+	x = x / 8;
+	x = x && 21;
+	x = x || 32;
 
 
 	ret x + y + a;

--- a/oc/test_files/invalid_function_pointer.ol
+++ b/oc/test_files/invalid_function_pointer.ol
@@ -24,7 +24,7 @@ pub fn main() -> i32 {
 	define fn(mut i32, i32) -> i32 as arithmetic_function;
 
 	//Just a random variable
-	let mut x:i32 := 3;
+	let mut x:i32 = 3;
 
 	//An attempt to call a variable that is not a function pointer. Should error out right here
 	ret @x(1, 3);

--- a/oc/test_files/invalid_length_string_initializer.ol
+++ b/oc/test_files/invalid_length_string_initializer.ol
@@ -9,8 +9,8 @@ fn string_init() -> char* {
 	//Invoke the string initializer with an extremely common error -
 	// forgetting that the string's true length is actually one more than
 	// what's shown due to the \0
-	let my_str:char[11] := "Hello world";
-	let ptr:char* := my_str;
+	let my_str:char[11] = "Hello world";
+	let ptr:char* = my_str;
 
 	ret ptr;
 }

--- a/oc/test_files/invalid_ternary_lhs.ol
+++ b/oc/test_files/invalid_ternary_lhs.ol
@@ -4,11 +4,11 @@
 */
 
 pub fn main() -> i32 {
-	let mut x:i32 := 3;
-	let mut y:i32 := 5
-	let mut z:i32 := 6;
+	let mut x:i32 = 3;
+	let mut y:i32 = 5
+	let mut z:i32 = 6;
 
-	(z == 6 ? x else y) := 32;
+	(z == 6 ? x else y) = 32;
 
 	ret x + y;
 }

--- a/oc/test_files/invalid_type_string_initializer.ol
+++ b/oc/test_files/invalid_type_string_initializer.ol
@@ -2,15 +2,15 @@
 * Author: Jack Robbins
 * This file will test a the parser's handling of string initializers
 * with invalid types. For instance, trying to do something like:
-*    let a:i16[] := "hi";
+*    let a:i16[] = "hi";
 */
 
 
 fn string_init() -> char* {
 	//Attempt to use a string initiailizer for a non-char[]. This will fail.
 	//In Ollie, string initializers only work for char[]
-	let my_str:i16[11] := "Hello world";
-	let ptr:char* := my_str;
+	let my_str:i16[11] = "Hello world";
+	let ptr:char* = my_str;
 
 	ret ptr;
 }

--- a/oc/test_files/invalid_union_member.ol
+++ b/oc/test_files/invalid_union_member.ol
@@ -12,8 +12,8 @@ define union my_union {
 
 pub fn mut_union(mut x:custom_union*) -> i32 {
 	//We'll use the special union pointer accessor here
-	x->x := 4;
-	x->y := 2;
+	x->x = 4;
+	x->y = 2;
 
 	//Try accessing an invalid type
 	ret x->a;
@@ -24,7 +24,7 @@ pub fn main() -> i32{
 	declare my_union:custom_union;
 	
 	//Store x
-	my_union.x := 32;
+	my_union.x = 32;
 
 	@mut_union(&my_union);
 	

--- a/oc/test_files/lex_test1.ol
+++ b/oc/test_files/lex_test1.ol
@@ -9,18 +9,18 @@ declare j:u8;
 alias u8[100] as int_arr;
 
 fn test_func(my_float:u32, ptr:void*) -> void{
-	let mut i:u32 := 0x01;
+	let mut i:u32 = 0x01;
 	//Cast ptr to an int
 
 	declare mut my_arr:i32[100];
 
-	my_arr[3] := 2;
+	my_arr[3] = 2;
 
-	let z:i32 := 3;
-	let x:i32 := -z;
+	let z:i32 = 3;
+	let x:i32 = -z;
 
 	//Example call
-	i := @never_defined(17);
+	i = @never_defined(17);
 
 	ret;
 }
@@ -30,13 +30,13 @@ fn never_defined(mut x:i32) -> u32{
 }
 
 pub fn main() -> i32 {
-	let mut i:u32 := 1;
-	let j:u32 := 1;
-	let j_ptr:u32* := &j;
-	let i_ptr:u32* := &i;
+	let mut i:u32 = 1;
+	let j:u32 = 1;
+	let j_ptr:u32* = &j;
+	let i_ptr:u32* = &i;
 
 	//Example call
-	i := @never_defined(2);
+	i = @never_defined(2);
 
 	ret *i_ptr + *j_ptr;
 }

--- a/oc/test_files/lex_test10.ol
+++ b/oc/test_files/lex_test10.ol
@@ -7,7 +7,7 @@ define struct my_struct{
 alias u8* as int_ptr;
 
 fn unused() -> u32{
-	let str_literal:char* := "I do nothing";
+	let str_literal:char* = "I do nothing";
 
 	ret 2;
 }
@@ -18,12 +18,12 @@ fn empty_func() -> void{
 
 
 fn my_func(error_code:u32) -> u32{
-	let l:u32 := 0;
-	let a:u32 := 1;
-	let k:u32 := 0;
+	let l:u32 = 0;
+	let a:u32 = 1;
+	let k:u32 = 0;
 	declare struct_arr:struct my_struct[300];
 
-	let struct_access:u32 := struct_arr[3]:i;
+	let struct_access:u32 = struct_arr[3]:i;
 	
 	declare i_do_not_exist:f64;
 }

--- a/oc/test_files/lex_test11.ol
+++ b/oc/test_files/lex_test11.ol
@@ -3,16 +3,16 @@
 */
 
 fn example(mut my_arr:i32*, max:u32) -> void{
-	*my_arr := 2+3 + 6-1;
+	*my_arr = 2+3 + 6-1;
 	ret;
 }
 
 pub fn main(argc:i32, argv:char**) -> i32 {
 	declare mut my_arr : i32[400];
-	my_arr[0] := 3;
+	my_arr[0] = 3;
 
-	let mut argc:u32 := 14;
-	//let mut example:u32 := 2;
+	let mut argc:u32 = 14;
+	//let mut example:u32 = 2;
 
 	while(argc > 0) {
 		argc--;

--- a/oc/test_files/lex_test12.ol
+++ b/oc/test_files/lex_test12.ol
@@ -14,19 +14,19 @@ define enum type_enum{
 } as my_enum_type;
 
 fn my_func(argv:char**) -> void{
-	let a:char** := argv;
+	let a:char** = argv;
 }
 
 pub fn main(argc:i32, argv:char**) -> i32{
-	let a:my_enum_type := TYPE_STRONG;
-	let mut b:u32 := 9 * 7 + 3 + a;
+	let a:my_enum_type = TYPE_STRONG;
+	let mut b:u32 = 9 * 7 + 3 + a;
 	//Should fail
 	while(b >= 9 && b <= 32) {
 		b--;
 	}
 	
 	if(a == TYPE_STRONG){
-		b := 32;
+		b = 32;
 	}
 
 	ret 32;

--- a/oc/test_files/lex_test2.ol
+++ b/oc/test_files/lex_test2.ol
@@ -1,15 +1,15 @@
 
 
 pub fn main() -> i32 {
-	let i:u32 := 0;
+	let i:u32 = 0;
 	//Useless, just testing
 	defer i++;
 
 	declare str:char*;
 	declare void_ptr:void*;
-	let bad:u32 := *void_ptr;
+	let bad:u32 = *void_ptr;
 
-	let my_str:char* := "I am a string";
+	let my_str:char* = "I am a string";
 	
 	ret 3;
 }

--- a/oc/test_files/lex_test3.ol
+++ b/oc/test_files/lex_test3.ol
@@ -12,17 +12,17 @@ pub fn main(arg_count:u32, arg_vector:str_arr) -> i32{
 	declare c:u32;
 
 	if(arg_count != 0) {
-		arg_count := -1;
-		//arg_vector := "hello";
+		arg_count = -1;
+		//arg_vector = "hello";
 
 	} else if(arg_count >= -1) {
-		let a:f32 := .23;
-		let b:f32 := 2.322;
-		let c:f32 := a + b;
+		let a:f32 = .23;
+		let b:f32 = 2.322;
+		let c:f32 = a + b;
 
 
 	} else {
-		arg_count := -2;
+		arg_count = -2;
 	}
 
 	ret c >> 3;

--- a/oc/test_files/lex_test4.ol
+++ b/oc/test_files/lex_test4.ol
@@ -5,8 +5,8 @@
 
 pub fn main() -> i32{
 	declare a:u32;
-	a := 23;
-	let b:u32 := 32;
+	a = 23;
+	let b:u32 = 32;
 
 	ret a + b;
 }

--- a/oc/test_files/lex_test5.ol
+++ b/oc/test_files/lex_test5.ol
@@ -1,19 +1,19 @@
 
 
 pub fn main(argc:i32, argv:char**) -> i32 {
-	let x : char := 'a';
-	let y : char := 'c';
+	let x : char = 'a';
+	let y : char = 'c';
 
-	let mut x:u64 := 1;
+	let mut x:u64 = 1;
 	
 	switch(x){
 		case 1 -> {
 			declare i : u32;
-			i := 32;
+			i = 32;
 		}
 
 		default -> {
-			x := 222;
+			x = 222;
 		}
 	}
 	

--- a/oc/test_files/lex_test6.ol
+++ b/oc/test_files/lex_test6.ol
@@ -4,15 +4,15 @@
 */
 
 fn tester() -> u32 {
-	let i:u16 := 0;
+	let i:u16 = 0;
 	
 	ret 3 * i;
 }
 
 
 pub fn main() -> i32 {
-	let i:u16 := 0;
-	let j:u16 := 0;
+	let i:u16 = 0;
+	let j:u16 = 0;
 	
 	ret i * j;
 }

--- a/oc/test_files/lex_test7.ol
+++ b/oc/test_files/lex_test7.ol
@@ -13,10 +13,10 @@ define struct con{
 pub fn main(argc:i32, argv:char**) -> i32
 {
 	if(argv) {
-		let i:str := "hi";
+		let i:str = "hi";
 	} else if(argc >= 2) {
 		if(argc == 3) {
-			let i:str := "hi";
+			let i:str = "hi";
 		}
 	}
 

--- a/oc/test_files/lex_test8.ol
+++ b/oc/test_files/lex_test8.ol
@@ -9,20 +9,20 @@ define struct my_struct{
 } as aliased_struct;
 
 pub fn main(argc:i32, argv:char**) -> i32 {
-	let i:u32 := 0;
+	let i:u32 = 0;
 	declare j:u32;
 
-	j := i;
+	j = i;
 
-	let k:u32 := 0;
-	let l:u32 := 0;
+	let k:u32 = 0;
+	let l:u32 = 0;
 	declare float_arr:f32[10];
 
 	if(i == 0) {
-		i := 2;
+		i = 2;
 	} else {
 		if(i == 3) {
-			i := 3;
+			i = 3;
 		}
 	}
 }

--- a/oc/test_files/lexical_scope_test.ol
+++ b/oc/test_files/lexical_scope_test.ol
@@ -3,18 +3,18 @@
 */
 
 pub fn main() -> i32 {
-	let mut x:i32 := 3;
-	let mut y:i32 := 5;
-	let mut z:i32 := 3;
+	let mut x:i32 = 3;
+	let mut y:i32 = 5;
+	let mut z:i32 = 3;
 
 	if( x == 0) {
-		let mut x:i32 := 35;
-		let mut y:i32 := 55;
+		let mut x:i32 = 35;
+		let mut y:i32 = 55;
 
-		 z := x + y;
+		 z = x + y;
 	} else {
-		let mut x:i8 := 3;
-		let mut y:i8 := 2;
+		let mut x:i8 = 3;
+		let mut y:i8 = 2;
 		ret x / y;
 	}
 

--- a/oc/test_files/logical_and_or_test.ol
+++ b/oc/test_files/logical_and_or_test.ol
@@ -5,12 +5,12 @@
 
 
 pub fn main(arc:i32, argv:char**) -> i32 {
-	let mut x:i32 := 73;
-	let mut y:i32 := 88;
+	let mut x:i32 = 73;
+	let mut y:i32 = 88;
 
-	let z:i32 := x || y;
-	let a:i32 := z && y;
-	let c:i32 := !a;
+	let z:i32 = x || y;
+	let a:i32 = z && y;
+	let c:i32 = !a;
 	
 	ret x + a + c;
 }

--- a/oc/test_files/mod_by_1.ol
+++ b/oc/test_files/mod_by_1.ol
@@ -4,7 +4,7 @@
 */
 
 pub fn main() -> i32 {
-	let mut x:i32 := 5;
+	let mut x:i32 = 5;
 
 	ret x % 1;
 }

--- a/oc/test_files/mod_test.ol
+++ b/oc/test_files/mod_test.ol
@@ -1,8 +1,8 @@
 pub fn main() -> i32{
-	let mut x:i32 := 3;
-	let mut y:i32 := x - 1;
+	let mut x:i32 = 3;
+	let mut y:i32 = x - 1;
 
-	let mut z:i32 := y % x;
+	let mut z:i32 = y % x;
 
 	ret z;
 }

--- a/oc/test_files/negative_in_switch.ol
+++ b/oc/test_files/negative_in_switch.ol
@@ -5,25 +5,25 @@
 */
 
 fn negative_c_style(arg:i32) -> i32{
-	let mut x:i32 := 32;
+	let mut x:i32 = 32;
 
 	switch(arg){
 		case 2:
-			x := 32;
+			x = 32;
 		case 1:
-			x := -3;
+			x = -3;
 		case 4: 
 			break;
 		case -3:
-			x := 211;
+			x = 211;
 			break;
 
 		case 6:
-			x := 22;
+			x = 22;
 			break;
 
 		default:
-			x := x - 22;
+			x = x - 22;
 			break;
 	}
 
@@ -32,26 +32,26 @@ fn negative_c_style(arg:i32) -> i32{
 }
 
 fn negative_ollie_style(arg:i32) -> i32{
-	let mut x:i32 := 32;
+	let mut x:i32 = 32;
 
 	switch(x){
 		case -3 -> {
-			x := 32;
+			x = 32;
 		}
 		case 1 -> {
-			x := -3;
+			x = -3;
 		}
 		case 4 -> {}
 		case 3 -> {
-			x := 211;
+			x = 211;
 		}
 
 		case 6 -> {
-			x := 22;
+			x = 22;
 		}
 
 		default -> {
-			x := x - 22;
+			x = x - 22;
 		}
 	}
 

--- a/oc/test_files/nested_c_switches.ol
+++ b/oc/test_files/nested_c_switches.ol
@@ -6,8 +6,8 @@
 
 
 pub fn main(argc:i32, argv:char**) -> i32 {
-	let mut x:i32 := 3;
-	let mut y:i32 := 5;
+	let mut x:i32 = 3;
+	let mut y:i32 = 5;
 
 	switch (argc) {
 		case 1:

--- a/oc/test_files/nested_loops.ol
+++ b/oc/test_files/nested_loops.ol
@@ -3,13 +3,13 @@
 */
 
 pub fn main(argc:i32, argv:char**) -> i32 {
-	let mut x:i32 := 3;
-	let mut y:i32 := -1;
+	let mut x:i32 = 3;
+	let mut y:i32 = -1;
 
-	for(let _:u32 := 0; _ < 3333; _++) {
-		for(let idx:u32 := 0; idx < 322; idx++) {
-			x := x - 3;	
-			y := y + x;
+	for(let _:u32 = 0; _ < 3333; _++) {
+		for(let idx:u32 = 0; idx < 322; idx++) {
+			x = x - 3;	
+			y = y + x;
 		}
 	}
 

--- a/oc/test_files/nested_switch.ol
+++ b/oc/test_files/nested_switch.ol
@@ -5,8 +5,8 @@
 
 
 pub fn main(argc:i32, argv:char**) -> i32 {
-	let mut x:i32 := 3;
-	let mut y:i32 := 5;
+	let mut x:i32 = 3;
+	let mut y:i32 = 5;
 
 	switch (argc) {
 		case 1 -> {

--- a/oc/test_files/nested_switch_default.ol
+++ b/oc/test_files/nested_switch_default.ol
@@ -5,8 +5,8 @@
 
 
 pub fn main(argc:i32, argv:char**) -> i32 {
-	let mut x:i32 := 3;
-	let mut y:i32 := 5;
+	let mut x:i32 = 3;
+	let mut y:i32 = 5;
 
 	switch (argc) {
 		case 1 -> {

--- a/oc/test_files/nested_switch_optimized.ol
+++ b/oc/test_files/nested_switch_optimized.ol
@@ -6,10 +6,10 @@
 
 
 pub fn main(argc:i32, argv:char**) -> i32 {
-	let mut x:i32 := 3;
-	let mut y:i32 := 5;
+	let mut x:i32 = 3;
+	let mut y:i32 = 5;
 	//This will be totally useless
-	let mut z:i32 := 0;
+	let mut z:i32 = 0;
 
 	switch (argc) {
 		case 1 -> {

--- a/oc/test_files/parameter_passing.ol
+++ b/oc/test_files/parameter_passing.ol
@@ -4,15 +4,15 @@
 */
 
 fn parameter_pass(x:i32, y:i32, z:i32, a:char, b:char, c:char) -> i32 {
-	let mut k:i32 := x + y + z;
-	let mut c:char := a + b + c;
+	let mut k:i32 = x + y + z;
+	let mut c:char = a + b + c;
 
 	ret k + c;
 }
 
 fn parameter_pass2(x:i32, y:i32, z:i32, a:char, b:char, c:char) -> i32 {
-	let mut k:i32 := x + y + z;
-	let mut c:char := a + b + c;
+	let mut k:i32 = x + y + z;
+	let mut c:char = a + b + c;
 
 	ret k + c;
 }
@@ -29,7 +29,7 @@ fn pcount_r(mut x:u64) -> u64 {
 			ret 1;
 		}
 
-		x := x + 1;
+		x = x + 1;
 	} else {
 		ret 0;
 	}
@@ -39,22 +39,22 @@ fn pcount_r(mut x:u64) -> u64 {
 
 
 pub fn main() -> i32{
-	let mut x:i32 := 3;
-	let mut y:i32 := x - 1;
-	let mut aa:i32 := x - y;
-	let mut bb:i32 := x - y;
-	let mut cc:i32 := x - y;
-	let mut dd:i32 := x - y;
-	let mut ee:i32 := x - y;
-	let mut ff:i32 := x - y;
+	let mut x:i32 = 3;
+	let mut y:i32 = x - 1;
+	let mut aa:i32 = x - y;
+	let mut bb:i32 = x - y;
+	let mut cc:i32 = x - y;
+	let mut dd:i32 = x - y;
+	let mut ee:i32 = x - y;
+	let mut ff:i32 = x - y;
 
-	let mut z:i32 := y + x;
-	let a:char := 'a';
-	let b:char := 'b';
-	let ch:char := 'c';
+	let mut z:i32 = y + x;
+	let a:char = 'a';
+	let b:char = 'b';
+	let ch:char = 'c';
 
-	let mut k:i32 := y / z + aa;
-	let mut c:i32 := y % k + cc + ee + ff;
+	let mut k:i32 = y / z + aa;
+	let mut c:i32 = y % k + cc + ee + ff;
 
 	//Testing complexities
 	if(k == 0) {

--- a/oc/test_files/pointer_arithmetic.ol
+++ b/oc/test_files/pointer_arithmetic.ol
@@ -4,11 +4,11 @@
 */
 
 pub fn main(argc:i32, argv:char**) -> i32 {
-	let mut x:i32 := 32;
-	let mut y:i32* := &x;
+	let mut x:i32 = 32;
+	let mut y:i32* = &x;
 
-	*y := x - 11;
-	*y := 32;
+	*y = x - 11;
+	*y = 32;
 
 	ret *y + x;
 }

--- a/oc/test_files/pointer_deref.ol
+++ b/oc/test_files/pointer_deref.ol
@@ -1,9 +1,9 @@
 pub fn main(argc:i32, argv:char**) -> i32 {
-	let mut x:u32 := 32;
+	let mut x:u32 = 32;
 	
-	let mut y:u32* := &x;
+	let mut y:u32* = &x;
 
-	*y := 32 + *y;
+	*y = 32 + *y;
 
 	ret *y;
 }

--- a/oc/test_files/pointer_reassignment.ol
+++ b/oc/test_files/pointer_reassignment.ol
@@ -18,10 +18,10 @@ define struct my_struct{
 */
 pub fn mutate_structure_pointer(mut struct_pointer:custom_struct*) -> i32 {
 	//Reassign the pointer
-	let mut ptr:custom_struct* := struct_pointer;
+	let mut ptr:custom_struct* = struct_pointer;
 
-	ptr=>y[2] := 32;
-	ptr=>lch := 'a';
+	ptr=>y[2] = 32;
+	ptr=>lch = 'a';
 
 	ret 0;
 }
@@ -32,10 +32,10 @@ pub fn mutate_structure_pointer(mut struct_pointer:custom_struct*) -> i32 {
 */
 pub fn mutate_structure_double_pointer(mut struct_pointer:custom_struct**) -> i32 {
 	//Reassign the pointer
-	let mut ptr:custom_struct* := *struct_pointer;
+	let mut ptr:custom_struct* = *struct_pointer;
 
-	ptr=>y[2] := 32;
-	ptr=>lch := 'a';
+	ptr=>y[2] = 32;
+	ptr=>lch = 'a';
 
 	ret 0;
 }
@@ -46,17 +46,17 @@ pub fn mutate_structure_double_pointer(mut struct_pointer:custom_struct**) -> i3
 */
 pub fn reassign_pointer() -> i32 {
 	//Declare and initialize a struct
-	let mut a:i32[] := [2, 3, 4, 5, 17];
+	let mut a:i32[] = [2, 3, 4, 5, 17];
 
 	//Some reassignment
-	a[2] := 2;
+	a[2] = 2;
 
 	//Pointer to a
-	let mut c:i32* := a;
+	let mut c:i32* = a;
 
 	//Some reassignment
-	c[1] := 2;
-	c[3] := 4;
+	c[1] = 2;
+	c[3] = 4;
 
 	//This will mark it
 	ret a[3]; // REALLY TRICKY HERE - C is still affecting this
@@ -65,9 +65,9 @@ pub fn reassign_pointer() -> i32 {
 
 pub fn main(arg:i32, argv:char**) -> i32{
 	//Declare and initialize a struct
-	let mut a:custom_struct := {'a', [2,3,4], 'b'};
+	let mut a:custom_struct = {'a', [2,3,4], 'b'};
 
-	let mut b:custom_struct* := &a;
+	let mut b:custom_struct* = &a;
 
 	//Call the mutator
 	@mutate_structure_pointer(b);

--- a/oc/test_files/postfix_operators.ol
+++ b/oc/test_files/postfix_operators.ol
@@ -8,20 +8,20 @@ pub fn main(arg:i32, argv:char**) -> i32 {
 	declare mut arr:i32[14][2];
 	declare mut oneD:i64[2];
 	
-	arr[3][1] := 3;
-	arr[5][2] := 3;
-	arr[7][0] := 2;
+	arr[3][1] = 3;
+	arr[5][2] = 3;
+	arr[7][0] = 2;
 
-	oneD[1] := 3;
+	oneD[1] = 3;
 
-	let mut x:i32 := 33;
+	let mut x:i32 = 33;
 
-	let mut i:i32 := 3;
+	let mut i:i32 = 3;
 	
 	if(arg == 2) {
-		arr[x][1] := 3;
+		arr[x][1] = 3;
 	} else {
-		i := arr[0][0];
+		i = arr[0][0];
 	}
 
 	//So it isn't optimized away

--- a/oc/test_files/postfix_testing.ol
+++ b/oc/test_files/postfix_testing.ol
@@ -19,20 +19,20 @@ pub fn postfix_in_use(arg:i32) -> i32{
 
 	switch(arg){
 		case 2 -> {
-			x := 32;
+			x = 32;
 		}
 		case 1 -> {
-			x := 3;
+			x = 3;
 		}
 		case 7 -> {
-			x := 2;
+			x = 2;
 		}
 		// Empty default
 		default -> {}
 	}
 
 	//Very basic initializer
-	let tester:my_struct := {x, 7, 'a'};
+	let tester:my_struct = {x, 7, 'a'};
 
 	//So it isn't optimized away
 	ret tester:x--;
@@ -44,20 +44,20 @@ pub fn main(arg:i32, argv:char**) -> i32{
 
 	switch(arg){
 		case 2 -> {
-			x := 32;
+			x = 32;
 		}
 		case 1 -> {
-			x := 3;
+			x = 3;
 		}
 		case 7 -> {
-			x := 2;
+			x = 2;
 		}
 		// Empty default
 		default -> {}
 	}
 
 	//Very basic initializer
-	let tester:my_struct := {x, 7, 'a'};
+	let tester:my_struct = {x, 7, 'a'};
 
 	//Postincrement this
 	tester:x++;

--- a/oc/test_files/predeclared_function.ol
+++ b/oc/test_files/predeclared_function.ol
@@ -7,7 +7,7 @@
 declare fn predeclared(mut i32, i16) -> i32;
 
 fn test_func() -> i32 {
-	let i:i32 := @predeclared(1, 3);
+	let i:i32 = @predeclared(1, 3);
 
 	ret i;
 }
@@ -18,7 +18,7 @@ fn predeclared(mut x:i32, y:i16) -> i32{
 
 pub fn main() -> i32 {
 	//Example call
-	let mut i:i32 := @test_func();
+	let mut i:i32 = @test_func();
 
 	ret i;
 }

--- a/oc/test_files/predeclared_function_bad_params.ol
+++ b/oc/test_files/predeclared_function_bad_params.ol
@@ -7,7 +7,7 @@
 declare fn predeclared(i32, mut i16) -> i32;
 
 fn test_func() -> i32 {
-	let i:i32 := @predeclared(1, 3);
+	let i:i32 = @predeclared(1, 3);
 
 	ret i;
 }
@@ -19,7 +19,7 @@ fn predeclared(mut x:i32, y:i16) -> i32{
 
 pub fn main() -> i32 {
 	//Example call
-	let mut i:i32 := @test_func();
+	let mut i:i32 = @test_func();
 
 	ret i;
 }

--- a/oc/test_files/predeclared_function_bad_params2.ol
+++ b/oc/test_files/predeclared_function_bad_params2.ol
@@ -7,7 +7,7 @@
 declare fn predeclared(i32, mut i16) -> i32;
 
 fn test_func() -> i32 {
-	let i:i32 := @predeclared(1, 3);
+	let i:i32 = @predeclared(1, 3);
 
 	ret i;
 }
@@ -19,7 +19,7 @@ fn predeclared(x:i64, mut y:i32) -> i64{
 
 pub fn main() -> i32 {
 	//Example call
-	let mut i:i32 := @test_func();
+	let mut i:i32 = @test_func();
 
 	ret i;
 }

--- a/oc/test_files/predeclared_function_bad_return_type.ol
+++ b/oc/test_files/predeclared_function_bad_return_type.ol
@@ -7,7 +7,7 @@
 declare fn predeclared(mut i32, i16) -> i32;
 
 fn test_func() -> i32 {
-	let i:i32 := @predeclared(1, 3);
+	let i:i32 = @predeclared(1, 3);
 
 	ret i;
 }
@@ -19,7 +19,7 @@ fn predeclared(mut x:i32, y:i16) -> i64{
 
 pub fn main() -> i32 {
 	//Example call
-	let mut i:i32 := @test_func();
+	let mut i:i32 = @test_func();
 
 	ret i;
 }

--- a/oc/test_files/predeclared_function_empty_params.ol
+++ b/oc/test_files/predeclared_function_empty_params.ol
@@ -7,7 +7,7 @@
 declare fn predeclared() -> i32;
 
 fn test_func() -> i32 {
-	let i:i32 := @predeclared();
+	let i:i32 = @predeclared();
 
 	ret i;
 }
@@ -18,7 +18,7 @@ fn predeclared() -> i32{
 
 pub fn main() -> i32 {
 	//Example call
-	let mut i:i32 := @test_func();
+	let mut i:i32 = @test_func();
 
 	ret i;
 }

--- a/oc/test_files/predeclared_function_void.ol
+++ b/oc/test_files/predeclared_function_void.ol
@@ -7,7 +7,7 @@
 declare fn predeclared(void) -> i32;
 
 fn test_func() -> i32 {
-	let i:i32 := @predeclared();
+	let i:i32 = @predeclared();
 
 	ret i;
 }
@@ -18,7 +18,7 @@ fn predeclared() -> i32{
 
 pub fn main() -> i32 {
 	//Example call
-	let mut i:i32 := @test_func();
+	let mut i:i32 = @test_func();
 
 	ret i;
 }

--- a/oc/test_files/prefix_assignability.ol
+++ b/oc/test_files/prefix_assignability.ol
@@ -19,23 +19,23 @@ pub fn main(arg:i32, argv:char**) -> i32{
 
 	switch(arg){
 		case 2 -> {
-			x := 32;
+			x = 32;
 		}
 		case 1 -> {
-			x := 3;
+			x = 3;
 		}
 		case 7 -> {
-			x := 2;
+			x = 2;
 		}
 		// Empty default
 		default -> {}
 	}
 
 	//Very basic initializer
-	let tester:my_struct := {x, 7, 'a'};
+	let tester:my_struct = {x, 7, 'a'};
 
 	// This should FAIL
-	++tester:x := 3;
+	++tester:x = 3;
 
 	//So it isn't optimized away
 	ret tester:x;

--- a/oc/test_files/prefix_testing.ol
+++ b/oc/test_files/prefix_testing.ol
@@ -27,13 +27,13 @@ pub fn main(arg:i32, argv:char**) -> i32{
 
 	switch(arg){
 		case 2 -> {
-			x := 32;
+			x = 32;
 		}
 		case 1 -> {
-			x := 3;
+			x = 3;
 		}
 		case 7 -> {
-			x := 2;
+			x = 2;
 		}
 		// Empty default
 		default -> {}
@@ -44,7 +44,7 @@ pub fn main(arg:i32, argv:char**) -> i32{
 	
 
 	//Very basic initializer
-	let tester:my_struct := {x, 7, 'a'};
+	let tester:my_struct = {x, 7, 'a'};
 
 	//preincrement this
 	++tester:x;

--- a/oc/test_files/prepost_op_testing.ol
+++ b/oc/test_files/prepost_op_testing.ol
@@ -18,11 +18,11 @@ pub fn struct_testing(arg:i32, argv:char**) -> i32{
 
 	declare mut structure:my_struct;
 
-	structure:ch := 'a';
-	structure:x[3] := 3;
-	structure:x[5] := 2;
-	structure:lch := 'b';
-	structure:y := 5;
+	structure:ch = 'a';
+	structure:x[3] = 3;
+	structure:x[5] = 2;
+	structure:lch = 'b';
+	structure:y = 5;
 
 	//Try to postdec
 	structure:ch--;
@@ -38,7 +38,7 @@ pub fn struct_testing(arg:i32, argv:char**) -> i32{
 pub fn main() -> i32 {
 	//The compiler should detect and count the number
 	//in the array initializer list.
-	let mut arr:i32[] := [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+	let mut arr:i32[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
 	arr[3]++;
 

--- a/oc/test_files/prepostop_pointers.ol
+++ b/oc/test_files/prepostop_pointers.ol
@@ -5,7 +5,7 @@
 
 //Test preopping
 pub fn preop_pointers(mut x:i32*) -> i32 {
-	(++x)[2] := 3;
+	(++x)[2] = 3;
 
 	ret x[3];
 
@@ -13,7 +13,7 @@ pub fn preop_pointers(mut x:i32*) -> i32 {
 
 //Test postopping
 pub fn postop_pointers(mut x:i32*) -> i32 {
-	(x++)[2] := 3;
+	(x++)[2] = 3;
 
 	ret x[3];
 }

--- a/oc/test_files/reg_alloc_stress_test.ol
+++ b/oc/test_files/reg_alloc_stress_test.ol
@@ -4,15 +4,15 @@
 */
 
 fn parameter_pass(x:i32, y:i32, z:i32, a:i32, b:i32, c:i32) -> i32 {
-	let mut k:i32 := x + y + z;
-	let mut c:i32 := a + b + c;
+	let mut k:i32 = x + y + z;
+	let mut c:i32 = a + b + c;
 
 	ret k + c;
 }
 
 fn parameter_pass2(x:i32, y:i32, z:i32, a:i32, b:i32, c:i32) -> i32 {
-	let mut k:i32 := x + y + z;
-	let mut c:i32 := a + b + c;
+	let mut k:i32 = x + y + z;
+	let mut c:i32 = a + b + c;
 
 	ret k + c;
 }
@@ -29,7 +29,7 @@ fn pcount_r(mut x:u64) -> u64 {
 			ret 1;
 		}
 
-		x := x + 1;
+		x = x + 1;
 	} else {
 		ret 0;
 	}
@@ -39,20 +39,20 @@ fn pcount_r(mut x:u64) -> u64 {
 
 
 pub fn main() -> i32{
-	let mut x:i32 := 3;
-	let mut y:i32 := x - 1;
-	let mut aa:i32 := x - y;
-	let mut bb:i32 := x - y;
-	let mut cc:i32 := x - y;
-	let mut dd:i32 := x - y;
+	let mut x:i32 = 3;
+	let mut y:i32 = x - 1;
+	let mut aa:i32 = x - y;
+	let mut bb:i32 = x - y;
+	let mut cc:i32 = x - y;
+	let mut dd:i32 = x - y;
 
-	let mut z:i32 := y + x;
-	let a:i32 := 'a';
-	let b:i32 := 'b';
-	let ch:i32 := 'c';
+	let mut z:i32 = y + x;
+	let a:i32 = 'a';
+	let b:i32 = 'b';
+	let ch:i32 = 'c';
 
-	let mut k:i32 := y / z + aa;
-	let mut c:i32 := y % k + cc;
+	let mut k:i32 = y / z + aa;
+	let mut c:i32 = y % k + cc;
 
 	//Testing complexities
 	ret @parameter_pass2(k+ 5, c * 3, z - 22, a, b, ch) + @parameter_pass(x, y, aa + bb, a, b, ch) + cc + dd;

--- a/oc/test_files/relational_testing.ol
+++ b/oc/test_files/relational_testing.ol
@@ -4,10 +4,10 @@
 */
 
 pub fn main() -> i32{
-	let mut x:i32 := 3;
-	let mut y:i32 := 3;
+	let mut x:i32 = 3;
+	let mut y:i32 = 3;
 
-	let z:i32 := x >= y;
+	let z:i32 = x >= y;
 
 	if(x <= y) {
 		ret 2;

--- a/oc/test_files/return-in-c-style-switch.ol
+++ b/oc/test_files/return-in-c-style-switch.ol
@@ -4,24 +4,24 @@
 */
 
 pub fn main(arg:i32, argv:char**) -> i32{
-	let mut x:i32 := 32;
+	let mut x:i32 = 32;
 
 	switch(arg){
 		case 2:
-			x := 32;
+			x = 32;
 		case 1:
-			x := -3;
+			x = -3;
 		case 4: 
 		case 3:
-			x := 211;
+			x = 211;
 			ret x + 1;
 
 		case 6:
-			x := 22;
+			x = 22;
 			break;
 
 		default:
-			x := x - 22;
+			x = x - 22;
 			ret x * 2;
 	}
 

--- a/oc/test_files/return_in_defer_test.ol
+++ b/oc/test_files/return_in_defer_test.ol
@@ -4,15 +4,15 @@
 */
 
 pub fn main() -> i32 {
-	let mut x:i32 := 3;
-	let mut y:i32 := 3;
+	let mut x:i32 = 3;
+	let mut y:i32 = 3;
 
 	//valid
 	defer {
 		y++;
 	}
 
-	y := y - 11;
+	y = y - 11;
 
 	defer {
 		ret y;

--- a/oc/test_files/returning_function_pointer.ol
+++ b/oc/test_files/returning_function_pointer.ol
@@ -42,7 +42,7 @@ fn choose_function(x:i32) -> arithmetic_function{
 
 
 pub fn main() -> i32{
-	let x:arithmetic_function := @choose_function(2);
+	let x:arithmetic_function = @choose_function(2);
 
 	ret @x(1, 3);
 }

--- a/oc/test_files/returning_ternary.ol
+++ b/oc/test_files/returning_ternary.ol
@@ -4,9 +4,9 @@
 */
 
 pub fn main() -> i32 {
-	let mut x:i32 := 2;
-	let mut a:i32 := 3;
-	let mut b:i32 := 3;
+	let mut x:i32 = 2;
+	let mut a:i32 = 3;
+	let mut b:i32 = 3;
 	
 	//Return the ternary
 	ret x == 0 ? a - 1 else b + 2;

--- a/oc/test_files/short_circuit.ol
+++ b/oc/test_files/short_circuit.ol
@@ -13,30 +13,30 @@ fn really_long_function(arg:i32) -> i32 {
 }
 
 pub fn main(arg:i32, argv:char**) -> i32{
-	let mut x:u32 := 232;
+	let mut x:u32 = 232;
 
 	defer {
-		x := x + 3;
+		x = x + 3;
 		@tester(x);
 	};
 
 	
 	if(arg < x && x != 1){
-		x := x - 3;
+		x = x - 3;
 	} else if(x < 2 && (x != 1 || x != 2)) {
-		x := x * 2;
+		x = x * 2;
 	} else {
-	 	x := x + 3;
+	 	x = x + 3;
 		ret x;
 	}
 	
 
 	//Assign B a start
-	let mut b:i32 := 33;
+	let mut b:i32 = 33;
 
 	do{
 		b--;
-		x := x - 1;
+		x = x - 1;
 	} while(x == 32 || b <= 32) ;
 
 	//So it isn't optimized away

--- a/oc/test_files/short_circuit_for_loop.ol
+++ b/oc/test_files/short_circuit_for_loop.ol
@@ -7,14 +7,14 @@ fn tester(arg:i32) -> void{
 }
 
 pub fn main(arg:i32, argv:char**) -> i32{
-	let mut x:u32 := 232;
+	let mut x:u32 = 232;
 
 	//Assign B a start
-	let mut b:i32 := 33;
+	let mut b:i32 = 33;
 
-	for(let a:u32 := 0; b != 0 || a < 33; a++) {
+	for(let a:u32 = 0; b != 0 || a < 33; a++) {
 		b--;
-		x := x - 5;
+		x = x - 5;
 	}
 
 	//So it isn't optimized away

--- a/oc/test_files/simple_for.ol
+++ b/oc/test_files/simple_for.ol
@@ -5,9 +5,9 @@
 
 pub fn main() -> i32 {
 	declare mut x:i32;
-	let mut y:i32 := 3;
+	let mut y:i32 = 3;
 
-	for(x := 0; x < 800; ++x){
+	for(x = 0; x < 800; ++x){
 		y += x;
 	}
 

--- a/oc/test_files/simple_let.ol
+++ b/oc/test_files/simple_let.ol
@@ -4,6 +4,6 @@
 */
 
 pub fn main() -> i32 {
-	let mut x:i32 := 81;
+	let mut x:i32 = 81;
 	ret x;
 }

--- a/oc/test_files/single_dimension_array.ol
+++ b/oc/test_files/single_dimension_array.ol
@@ -6,18 +6,18 @@ pub fn main(arg:i32, argv:char**) -> i32{
 	//The array that we have
 	declare mut arr:i32[14];
 
-	arr[3] := 3;
-	arr[5] := 3;
-	arr[7] := 2;
+	arr[3] = 3;
+	arr[5] = 3;
+	arr[7] = 2;
 
-	let mut x:i32 := 33;
+	let mut x:i32 = 33;
 
-	let mut i:i32 := 3;
+	let mut i:i32 = 3;
 	
 	if(arg == 2){
-		arr[x] := i;
+		arr[x] = i;
 	} else {
-		i := arr[0];
+		i = arr[0];
 	}
 
 	//So it isn't optimized away

--- a/oc/test_files/ssa_test1.ol
+++ b/oc/test_files/ssa_test1.ol
@@ -5,13 +5,13 @@
 
 // Test function
 fn tester() -> i32 {
-	let mut x:u32 := 232;
+	let mut x:u32 = 232;
 
 	if(x == 327) {
 		ret x;
 	}
 
-	x := x + 33;
+	x = x + 33;
 
 	ret -1;
 }
@@ -19,28 +19,28 @@ fn tester() -> i32 {
 
 
 pub fn main() -> i32{
-	let mut y:i32 := 23;
-	let mut x:i32 := 3;
-	let mut z:i32 := 322;
+	let mut y:i32 = 23;
+	let mut x:i32 = 3;
+	let mut z:i32 = 322;
 
 	//Statically known use - the goal of SSA
 	if(x > 4) {
-		y := x - 2;
+		y = x - 2;
 		ret y;
 	} else if (x == 4) {
-		y := x + 9;
+		y = x + 9;
 	} else {
-		y := x + 12;
+		y = x + 12;
 	}
 	
 	//Phi function should be here
-	let w:i32 := x + y;
+	let w:i32 = x + y;
 
 	
 	/*
-	for(let i:u32 := 0; i <= 322; ++i){
+	for(let i:u32 = 0; i <= 322; ++i){
 		//declare w:i32;
-		//w := w + 3;
+		//w = w + 3;
 	}
 	*/
 

--- a/oc/test_files/ssa_test10.ol
+++ b/oc/test_files/ssa_test10.ol
@@ -3,21 +3,21 @@
 */
 
 fn other_test(mut a:i32*) -> void{
-	let mut l:i32 := 33;
-	let mut j:i32 := 3232;
+	let mut l:i32 = 33;
+	let mut j:i32 = 3232;
 
 	if(l == 32) {
-		l := l + 3222;
-		j := 323;
+		l = l + 3222;
+		j = 323;
 		if(j == 323) {
-			let mut z:i32 := 32;
+			let mut z:i32 = 32;
 		}
 	} else {
-		l := 32;
-		j := l + 3;
+		l = 32;
+		j = l + 3;
 	}
 
-	*a := j + 2;
+	*a = j + 2;
 
 	ret;
 }
@@ -25,20 +25,20 @@ fn other_test(mut a:i32*) -> void{
 
 
 pub fn main() -> i32{
-	let mut x:i32 := 33;
-	let mut y:i32 := 3232;
+	let mut x:i32 = 33;
+	let mut y:i32 = 3232;
 
 	if(x <= 32) {
-		x := x + 22;
+		x = x + 22;
 	} else if(x == 23) {
-		x:= 323;
+		x= 323;
 	} else if(x == 36) {
-		x := 32222;
+		x = 32222;
 	} else {
-		x := 32;
+		x = 32;
 	}
 
-	x := x + 322;
+	x = x + 322;
 
 	idle;
 

--- a/oc/test_files/ssa_test11.ol
+++ b/oc/test_files/ssa_test11.ol
@@ -3,13 +3,13 @@
 */
 
 pub fn main() -> i32{
-	let mut x:i32 := 33;
-	let mut y:i32 := 3232;
+	let mut x:i32 = 33;
+	let mut y:i32 = 3232;
 
 	while(x <= 32){
-		x := x * 3 + x;
+		x = x * 3 + x;
 	}
 
-	x := x + 3;
+	x = x + 3;
 	ret x;
 }

--- a/oc/test_files/ssa_test2.ol
+++ b/oc/test_files/ssa_test2.ol
@@ -3,7 +3,7 @@
 */
 
 pub fn main() -> i32{
-	let mut x:u32 := 33;
+	let mut x:u32 = 33;
 	defer {
 		x++;
 	};
@@ -13,6 +13,6 @@ pub fn main() -> i32{
 	}
 	
 
-	x := 323;
+	x = 323;
 	ret 0;
 }

--- a/oc/test_files/ssa_test3.ol
+++ b/oc/test_files/ssa_test3.ol
@@ -3,12 +3,12 @@
 */
 
 pub fn main() -> i32{
-	let mut x:u32 := 33;
+	let mut x:u32 = 33;
 
 	if( x == 3222) {
 		ret x;
 	} else if (x == 11) {
-		x := x + 33;
+		x = x + 33;
 	} else {
 		x--;
 	}

--- a/oc/test_files/ssa_test4.ol
+++ b/oc/test_files/ssa_test4.ol
@@ -3,12 +3,12 @@
 */
 
 pub fn main() -> i32{
-	let mut x:u32 := 33;
+	let mut x:u32 = 33;
 
-	x := 3222;
+	x = 3222;
 
-	for(let mut i:u32 := 3; i <= 323; ++i){
-		x := 3;
+	for(let mut i:u32 = 3; i <= 323; ++i){
+		x = 3;
 		break when( x == 5);
 	}
 

--- a/oc/test_files/ssa_test5.ol
+++ b/oc/test_files/ssa_test5.ol
@@ -3,13 +3,13 @@
 */
 
 pub fn main() -> i32{
-	let mut x:i32 := 33;
+	let mut x:i32 = 33;
 
-	x := 3222;
+	x = 3222;
 
 	if(x <= 32) {
 		if(x == 70) {
-			x := x + -1;
+			x = x + -1;
 		}
 	} else if(x == 77) 	{
 		ret x - 4;
@@ -17,11 +17,11 @@ pub fn main() -> i32{
 		ret x + 4555;
 	} else {
 		//if(x > 32) {
-			x := x - 22222222;
+			x = x - 22222222;
 		//}
 	}
 
-	x := -1;
+	x = -1;
 
 	ret 0;
 }

--- a/oc/test_files/ssa_test6.ol
+++ b/oc/test_files/ssa_test6.ol
@@ -3,29 +3,29 @@
 */
 
 //Global variables
-let mut glob_x:u32 := 3232;
-let glog_y:i32 := -232;
+let mut glob_x:u32 = 3232;
+let glog_y:i32 = -232;
 
 pub fn main() -> i32{
-	let mut x:i32 := 33;
-	let mut y:i32 := 3232;
+	let mut x:i32 = 33;
+	let mut y:i32 = 3232;
 
-	x := 3222;
+	x = 3222;
 
 	if(x <= 32) {
-		x := x + 22;
+		x = x + 22;
 	} else {
-		x := x - 3;
-		y := 11;
+		x = x - 3;
+		y = 11;
 	}
 
 	idle;
 
 	//while(x <= 322) do{
 	//do{
-//	for(let _:u32 := 0; _ <= 323; _++) do{
-		x := x + 33;
-		y := y - 1;
+//	for(let _:u32 = 0; _ <= 323; _++) do{
+		x = x + 33;
+		y = y - 1;
 
 	//	break when(x == 32);
 	}//while(x <= 322);

--- a/oc/test_files/ssa_test7.ol
+++ b/oc/test_files/ssa_test7.ol
@@ -5,64 +5,64 @@
 //Global variables
 
 fn other_test() -> void{
-	let mut l:i32 := 33;
-	let mut j:i32 := 3232;
-let mut glob_x:u32 := 3232;
-let glog_y:i32 := -232;
+	let mut l:i32 = 33;
+	let mut j:i32 = 3232;
+let mut glob_x:u32 = 3232;
+let glog_y:i32 = -232;
 
 
 	if(l == 32)  {
-		glob_x := 23;
-		l := l + 3222;
-		j := 323;
+		glob_x = 23;
+		l = l + 3222;
+		j = 323;
 	} else {
-		l := 32;
-		j := l + 3;
+		l = 32;
+		j = l + 3;
 	}
 
-	let mut asd:i32 := l + j;
+	let mut asd:i32 = l + j;
 }
 
 
 fn tester() -> void{
-	let mut x:i32 := 33;
-	let mut y:i32 := 3232;
+	let mut x:i32 = 33;
+	let mut y:i32 = 3232;
 
-let mut glob_x:u32 := 3232;
-let glog_y:i32 := -232;
+let mut glob_x:u32 = 3232;
+let glog_y:i32 = -232;
 	if(x <= 32) {
-		x := x + 22;
+		x = x + 22;
 	} else if(x == 23)  {
-		x:= 323;
+		x= 323;
 	} else if(x == 36)  {
-		x := 32222;
+		x = 32222;
 	} else {
-		x := 32;
+		x = 32;
 	}
 
-	x := x + 322;
+	x = x + 322;
 }
 
 
 
 pub fn main() -> i32{
-	let mut x:i32 := 33;
-	let mut y:i32 := 3232;
+	let mut x:i32 = 33;
+	let mut y:i32 = 3232;
 
-let mut glob_x:u32 := 3232;
-let glog_y:i32 := -232;
-	x := 3222;
-	for(let _:i32 := 2; _ < 23; _++) {
+let mut glob_x:u32 = 3232;
+let glog_y:i32 = -232;
+	x = 3222;
+	for(let _:i32 = 2; _ < 23; _++) {
 		if(x <= 32) {
-			x := x + 22;
+			x = x + 22;
 		} else {
-			x := x - 3;
-			y := 11;
+			x = x - 3;
+			y = 11;
 
 			if( x - y == 0) {
-				x := 32;
+				x = 32;
 			} else {
-				y := 32;
+				y = 32;
 			}
 		}
 	}

--- a/oc/test_files/ssa_test8.ol
+++ b/oc/test_files/ssa_test8.ol
@@ -9,11 +9,11 @@ fn println(a:i32) -> void{
 }
 
 pub fn main() -> i32{
-	let mut x:i32 := 33;
-	let mut y:i32 := 3232;
+	let mut x:i32 = 33;
+	let mut y:i32 = 3232;
 
 
-	let mut abc:i32 := 3232;
+	let mut abc:i32 = 3232;
 
 	defer{
 	@println(abc);
@@ -21,24 +21,24 @@ pub fn main() -> i32{
 
 	//100% useless
 	if(abc == 3)  {
-		abc := 2;
+		abc = 2;
 	} else {
-		abc := 3;
-		x := 3;
+		abc = 3;
+		x = 3;
 	}
 
 	if(x == 32)  {
-		x := x + 3222;
-		y := 323;
+		x = x + 3222;
+		y = 323;
 	} else {
-		x := 32;
-		y := x + y + 3;
+		x = 32;
+		y = x + y + 3;
 	}
 
-	let mut w:i32 := x + y;
+	let mut w:i32 = x + y;
 
-	//w := 327;
-	//w := 322;
+	//w = 327;
+	//w = 322;
 
 	idle;
 

--- a/oc/test_files/ssa_test9.ol
+++ b/oc/test_files/ssa_test9.ol
@@ -4,24 +4,24 @@
 
 //Global variables
 fn other_test() -> void{
-let mut glob_x:u32 := 3232;
-let glog_y:i32 := -232;
+let mut glob_x:u32 = 3232;
+let glog_y:i32 = -232;
 
 
-	let mut l:i32 := 33;
-	let mut j:i32 := 3232;
+	let mut l:i32 = 33;
+	let mut j:i32 = 3232;
 
 	if(l == 32) {
-		l := l + 3222;
-		j := 323;
-		let mut iii:i32 := -2;
+		l = l + 3222;
+		j = 323;
+		let mut iii:i32 = -2;
 		@other_test();
 	} else {
-		l := 32;
-		j := l + 3;
+		l = 32;
+		j = l + 3;
 	}
 
-	let mut asd:i32 := l + j;
+	let mut asd:i32 = l + j;
 	ret;
 }
 

--- a/oc/test_files/string_array_initialization.ol
+++ b/oc/test_files/string_array_initialization.ol
@@ -6,8 +6,8 @@
 
 fn string_init() -> char** {
 	//Invoke the string initializer
-	let my_str:char*[] := ["Hello world", "hi", "hello", "what's up"];
-	let ptr:char** := my_str;
+	let my_str:char*[] = ["Hello world", "hi", "hello", "what's up"];
+	let ptr:char** = my_str;
 
 	ret ptr;
 }

--- a/oc/test_files/string_initializer.ol
+++ b/oc/test_files/string_initializer.ol
@@ -6,8 +6,8 @@
 
 fn string_init() -> char* {
 	//Invoke the string initializer
-	let my_str:char[] := "Hello world";
-	let ptr:char* := my_str;
+	let my_str:char[] = "Hello world";
+	let ptr:char* = my_str;
 
 	ret ptr;
 }

--- a/oc/test_files/string_initializer2.ol
+++ b/oc/test_files/string_initializer2.ol
@@ -8,7 +8,7 @@ alias char as character;
 
 fn string_init() -> char {
 	//Invoke the string initializer
-	let my_str:character[] := "The quick brown fox";
+	let my_str:character[] = "The quick brown fox";
 
 	//And return it
 	ret my_str[2];

--- a/oc/test_files/string_optimizer.ol
+++ b/oc/test_files/string_optimizer.ol
@@ -15,9 +15,9 @@ fn handling_string(a:char*, b:char*) -> char{
 
 
 pub fn main(argc:i32, argv:char**) -> i32 {
-	let my_string:char* := "Hello";
+	let my_string:char* = "Hello";
 	//This should be useless and optimized away
-	let string_arr:char* := " world";
+	let string_arr:char* = " world";
 
 	ret @handling_string(my_string, "world")
 		+ @handling_string("direct", "strings");

--- a/oc/test_files/struct_in_struct.ol
+++ b/oc/test_files/struct_in_struct.ol
@@ -30,14 +30,14 @@ pub fn main(arg:i32, argv:char**) -> i32{
 
 	switch(arg){
 		case 2 -> {
-			parent:internal:x := 32;
-			internal_struct:x := 322;
+			parent:internal:x = 32;
+			internal_struct:x = 322;
 		}
 		case 1 -> {
-			parent:internal:x := 32;
+			parent:internal:x = 32;
 		}
 		case 7 -> {
-			parent:internal:y := 32;
+			parent:internal:y = 32;
 		}
 
 		// Empty default

--- a/oc/test_files/struct_in_union.ol
+++ b/oc/test_files/struct_in_union.ol
@@ -22,8 +22,8 @@ pub fn main() -> i32{
 	declare my_union:custom_union;
 	
 	//Store x
-	my_union.x:a := 32;
-	my_union.x:y := 'a';
+	my_union.x:a = 32;
+	my_union.x:y = 'a';
 	
 	//Read as char
 	ret my_union.ch + my_union.x:x;

--- a/oc/test_files/struct_initializer.ol
+++ b/oc/test_files/struct_initializer.ol
@@ -19,20 +19,20 @@ pub fn main(arg:i32, argv:char**) -> i32{
 
 	switch(arg){
 		case 2 -> {
-			x := 32;
+			x = 32;
 		}
 		case 1 -> {
-			x := 3;
+			x = 3;
 		}
 		case 7 -> {
-			x := 2;
+			x = 2;
 		}
 		// Empty default
 		default -> {}
 	}
 
 	//Very basic initializer
-	let tester:my_struct := {x, 7, 'a'};
+	let tester:my_struct = {x, 7, 'a'};
 
 	//So it isn't optimized away
 	ret tester:x;

--- a/oc/test_files/struct_pointer_deref.ol
+++ b/oc/test_files/struct_pointer_deref.ol
@@ -17,8 +17,8 @@ define struct my_struct{
 * A function that will mutate a structure in its entirety
 */
 pub fn mutate_structure_pointer(mut struct_pointer:custom_struct*) -> i32 {
-	(*struct_pointer):y[2] := 32;
-	(*struct_pointer):lch := 'a';
+	(*struct_pointer):y[2] = 32;
+	(*struct_pointer):lch = 'a';
 
 	ret (*struct_pointer):lch;
 }
@@ -26,7 +26,7 @@ pub fn mutate_structure_pointer(mut struct_pointer:custom_struct*) -> i32 {
 
 pub fn main(arg:i32, argv:char**) -> i32{
 	//Declare and initialize a struct
-	let mut a:custom_struct := {'a', [2,3,4], 'b'};
+	let mut a:custom_struct = {'a', [2,3,4], 'b'};
 
 	//Call the mutator
 	@mutate_structure_pointer(&a);

--- a/oc/test_files/struct_pointers.ol
+++ b/oc/test_files/struct_pointers.ol
@@ -17,8 +17,8 @@ define struct my_struct{
 * A function that will mutate a structure in its entirety
 */
 pub fn mutate_structure_pointer(mut struct_pointer:custom_struct*) -> i32 {
-	struct_pointer=>y[2] := 32;
-	struct_pointer=>lch := 'a';
+	struct_pointer=>y[2] = 32;
+	struct_pointer=>lch = 'a';
 
 	ret 0;
 }
@@ -26,7 +26,7 @@ pub fn mutate_structure_pointer(mut struct_pointer:custom_struct*) -> i32 {
 
 pub fn main(arg:i32, argv:char**) -> i32{
 	//Declare and initialize a struct
-	let mut a:custom_struct := {'a', [2,3,4], 'b'};
+	let mut a:custom_struct = {'a', [2,3,4], 'b'};
 
 	//Call the mutator
 	@mutate_structure_pointer(&a);

--- a/oc/test_files/structures.ol
+++ b/oc/test_files/structures.ol
@@ -8,18 +8,18 @@ pub fn main(arg:i32, argv:char**) -> i32{
 		y:i32;
 	} as my_struct;
 
-	let mut x:i32 := 32;
-	let mut _:u32 := 2;
+	let mut x:i32 = 32;
+	let mut _:u32 = 2;
 
 	switch(x){
 		case 2 -> {
-			x := 32;
+			x = 32;
 		}
 		case 1 -> {
-			x := 3;
+			x = 3;
 		}
 		case 33 -> {
-			x := 2;
+			x = 2;
 		}
 		// Empty default
 		default -> {}

--- a/oc/test_files/switch-c-style1.ol
+++ b/oc/test_files/switch-c-style1.ol
@@ -4,24 +4,24 @@
 */
 
 pub fn main(arg:i32, argv:char**) -> i32{
-	let mut x:i32 := 32;
+	let mut x:i32 = 32;
 
 	switch(arg){
 		case 2:
-			x := 32;
+			x = 32;
 		case 1:
-			x := -3;
+			x = -3;
 		case 4: 
 		case 3:
-			x := 211;
+			x = 211;
 			break;
 
 		case 6:
-			x := 22;
+			x = 22;
 			break;
 
 		default:
-			x := x - 22;
+			x = x - 22;
 			break;
 	}
 

--- a/oc/test_files/switch-c-style2.ol
+++ b/oc/test_files/switch-c-style2.ol
@@ -4,31 +4,31 @@
 */
 
 pub fn main(arg:i32, argv:char**) -> i32{
-	let mut x:i32 := 32;
-	let mut y:i32 := 16;
+	let mut x:i32 = 32;
+	let mut y:i32 = 16;
 
 	switch(arg){
 		case 11:
-			x := 32;
+			x = 32;
 			y *= 2;
 			break;
 		case 1:
-			x := -3;
+			x = -3;
 			while(x != 0){
 				x -= 1;
 			}
 		case 4: 
 			break when(y == 3);
 		case 3:
-			x := 211;
+			x = 211;
 			break;
 
 		case 6:
-			x := 22;
+			x = 22;
 			break;
 
 		default:
-			x := x - 22;
+			x = x - 22;
 			break;
 	}
 

--- a/oc/test_files/switch_ollie_enum.ol
+++ b/oc/test_files/switch_ollie_enum.ol
@@ -15,26 +15,26 @@ define enum type_enum{
 } as my_enum_type;
 
 fn tester(param:my_enum_type) -> i32{
-	let mut x:i32 := 32;
+	let mut x:i32 = 32;
 
 	switch(param){
 		case TYPE_ONE -> {
-			x := 32;
+			x = 32;
 		}
 		case TYPE_TWO -> {
-			x := -3;
+			x = -3;
 		}
 		case TYPE_FOUR -> {}
 		case TYPE_THREE -> {
-			x := 211;
+			x = 211;
 		}
 
 		case TYPE_FIVE -> {
-			x := 22;
+			x = 22;
 		}
 
 		default -> {
-			x := x - 22;
+			x = x - 22;
 		}
 	}
 

--- a/oc/test_files/switch_ollie_enum2.ol
+++ b/oc/test_files/switch_ollie_enum2.ol
@@ -15,26 +15,26 @@ define enum type_enum{
 } as my_enum_type;
 
 fn tester(param:i32) -> i32{
-	let mut x:i32 := 32;
+	let mut x:i32 = 32;
 
 	switch(param){
 		case TYPE_ONE -> {
-			x := 32;
+			x = 32;
 		}
 		case TYPE_TWO -> {
-			x := -3;
+			x = -3;
 		}
 		case 7 -> {}
 		case TYPE_THREE -> {
-			x := 211;
+			x = 211;
 		}
 
 		case 9 -> {
-			x := 22;
+			x = 22;
 		}
 
 		default -> {
-			x := x - 22;
+			x = x - 22;
 		}
 	}
 

--- a/oc/test_files/switch_ollie_enum_arithmetic.ol
+++ b/oc/test_files/switch_ollie_enum_arithmetic.ol
@@ -16,27 +16,27 @@ define enum type_enum{
 
 
 fn tester(param:my_enum_type) -> i32{
-	let mut x:i32 := 32;
+	let mut x:i32 = 32;
 
 	//Test the type system's ability to deal with this
 	switch(param - 3){
 		case TYPE_ONE -> {
-			x := 32;
+			x = 32;
 		}
 		case TYPE_TWO -> {
-			x := -3;
+			x = -3;
 		}
 		case TYPE_FOUR -> {}
 		case TYPE_THREE -> {
-			x := 211;
+			x = 211;
 		}
 
 		case TYPE_FIVE -> {
-			x := 22;
+			x = 22;
 		}
 
 		default -> {
-			x := x - 22;
+			x = x - 22;
 		}
 	}
 

--- a/oc/test_files/switch_ternary_input.ol
+++ b/oc/test_files/switch_ternary_input.ol
@@ -5,26 +5,26 @@
 */
 
 pub fn main(argc:i32, argv:char**) -> i32{
-	let mut x:i32 := 32;
+	let mut x:i32 = 32;
 
 	switch(argc < 2 ? x else argc){
 		case 2 -> {
-			x := 32;
+			x = 32;
 		}
 		case 1 -> {
-			x := -3;
+			x = -3;
 		}
 		case 4 -> {}
 		case 3 -> {
-			x := 211;
+			x = 211;
 		}
 
 		case 6 -> {
-			x := 22;
+			x = 22;
 		}
 
 		default -> {
-			x := x - 22;
+			x = x - 22;
 		}
 	}
 

--- a/oc/test_files/ternary_in_for.ol
+++ b/oc/test_files/ternary_in_for.ol
@@ -4,14 +4,14 @@
 */
 
 pub fn main() -> i32 {
-	let mut x:i32 := 2;
-	let mut a:i32 := 3;
-	let mut b:i32 := 3;
+	let mut x:i32 = 2;
+	let mut a:i32 = 3;
+	let mut b:i32 = 3;
 
-	let mut test:i32 := 0;
+	let mut test:i32 = 0;
 	
 	//Ternary inside of the for loop
-	for(let mut i:i32 := a == 3 ? x else 1; i < 32; i++) {
+	for(let mut i:i32 = a == 3 ? x else 1; i < 32; i++) {
 		test++;
 	}
 

--- a/oc/test_files/ternary_in_ternary.ol
+++ b/oc/test_files/ternary_in_ternary.ol
@@ -4,12 +4,12 @@
 */
 
 pub fn main() -> i32 {
-	let mut x:i32 := 3;
-	let mut y:i32 := 4;
-	let mut z:i32 := 5;
-	let mut a:i32 := 6;
+	let mut x:i32 = 3;
+	let mut y:i32 = 4;
+	let mut z:i32 = 5;
+	let mut a:i32 = 6;
 
-	let ret_val:i32 := x == 2 ? x else (x == 3 ? z else a);
+	let ret_val:i32 = x == 2 ? x else (x == 3 ? z else a);
 
 	ret ret_val;
 }

--- a/oc/test_files/ternary_test.ol
+++ b/oc/test_files/ternary_test.ol
@@ -4,11 +4,11 @@
 */
 
 pub fn main() -> i32 {
-	let mut x:i32 := 2;
-	let mut a:i32 := 3;
-	let mut b:i32 := 3;
+	let mut x:i32 = 2;
+	let mut a:i32 = 3;
+	let mut b:i32 = 3;
 	
-	let mut test:i32 := x == 0 ? a else b;
+	let mut test:i32 = x == 0 ? a else b;
 	
 
 	ret test;//c;

--- a/oc/test_files/test_prog1.ol
+++ b/oc/test_files/test_prog1.ol
@@ -20,9 +20,9 @@ fn my_func(mut args:u32) -> u32{
 		args++;
 	} 
 
-	for(let mut i:u32 := 0; i < 232; i++){
+	for(let mut i:u32 = 0; i < 232; i++){
 		i--;
-		let j:i32 := 32;
+		let j:i32 = 32;
 		continue when (i == 32);
 	}
 
@@ -31,7 +31,7 @@ fn my_func(mut args:u32) -> u32{
 
 
 fn test_func(mut i:u32) -> void{
-	i := 32;
+	i = 32;
 }
 
 
@@ -39,23 +39,23 @@ pub fn main(argc:i32, argv:char**) -> i32{
 	//Allocate a struct
 	declare mut my_structure:my_struct;
 
-	my_structure:a := 2;
-	my_structure:b := 3;
-	my_structure:c := 32;
+	my_structure:a = 2;
+	my_structure:b = 3;
+	my_structure:c = 32;
 
-	let j:i64 := 2342l;
+	let j:i64 = 2342l;
 
 	//Sample call
 	@test_func(2);
 
-	let mut idx:u32 := 0;
+	let mut idx:u32 = 0;
 
 	while(idx < 15){
-		let bab:u32 := @my_func(idx);
+		let bab:u32 = @my_func(idx);
 		idx++;
 	}
 	
-	idx := 23;
+	idx = 23;
 
 	do{
 		idx--;
@@ -63,13 +63,13 @@ pub fn main(argc:i32, argv:char**) -> i32{
 
 		if(idx == 12)  {
 			ret idx;
-			idx := 23;
+			idx = 23;
 		}
 
 	} while (idx > 0);
 
 	//Example for loop
-	for(let mut i:u32 := 0; i <= 234; i := i + 2){
+	for(let mut i:u32 = 0; i <= 234; i = i + 2){
 		@test_func(i);
 	}
 

--- a/oc/test_files/test_prog10.ol
+++ b/oc/test_files/test_prog10.ol
@@ -8,15 +8,15 @@ fn tester(i:u32) -> i32{
  */
 pub fn main() -> i32{
 	
-	let a:i32 := 23;
+	let a:i32 = 23;
 
 
 	
  	declare arr:i32[32][3];
 
-	arr[1][2] := 23;
+	arr[1][2] = 23;
 
-	let b:i32 := arr[3][2];
+	let b:i32 = arr[3][2];
 
 	while(a < 32){
 		a--;

--- a/oc/test_files/test_prog11.ol
+++ b/oc/test_files/test_prog11.ol
@@ -3,9 +3,9 @@
  * For multi-layer array access
  */
 pub fn main() -> i32{
-	let a:i32 := 23;
-	let mut b:i32 := 3232;
-	let c:i32 := 322322;
+	let a:i32 = 23;
+	let mut b:i32 = 3232;
+	let c:i32 = 322322;
 
 	c++;
 	
@@ -14,10 +14,10 @@ pub fn main() -> i32{
  	declare arr:i32[32][3];
 
 	//Let's try and populate
-	arr[1][2] := 23;
+	arr[1][2] = 23;
 
 	//Now let's try and access
-	b := arr[3][2];
+	b = arr[3][2];
 	
 	
 
@@ -25,9 +25,9 @@ pub fn main() -> i32{
 	//Let's do simple access to make sure that it still works
 	declare b_arr:i8[3];
 
-	b_arr[2] := 'a';
+	b_arr[2] = 'a';
 
-	let a_temp:i32 := b_arr[2];
+	let a_temp:i32 = b_arr[2];
 
 	defer {a++;}
 	

--- a/oc/test_files/test_prog12.ol
+++ b/oc/test_files/test_prog12.ol
@@ -3,10 +3,10 @@
  * For multi-layer array access
  */
 pub fn main() -> i32{
-	let mut i:u32 := 333;
+	let mut i:u32 = 333;
 
-	for(let mut i:u32 := 0; i < 32332; i++) {
-		i := 33;
+	for(let mut i:u32 = 0; i < 32332; i++) {
+		i = 33;
 	}
 
 

--- a/oc/test_files/test_prog13.ol
+++ b/oc/test_files/test_prog13.ol
@@ -3,11 +3,11 @@
  * Testing do-while
  */
 pub fn main() -> i32{
-	let mut i:u32 := 333;
+	let mut i:u32 = 333;
 
-	for(let mut i:u32 := 333; i < 324252; i++){
+	for(let mut i:u32 = 333; i < 324252; i++){
 		declare u:i32;
-		i := i - 3;
+		i = i - 3;
 		continue when(i == 33);
 
 	}

--- a/oc/test_files/test_prog14.ol
+++ b/oc/test_files/test_prog14.ol
@@ -8,9 +8,9 @@ fn tester(a:u32) -> u32 {
 }
 
 pub fn main(argc:i32, argv:char**) -> i32 {
-	let mut a:u32 := 32;
+	let mut a:u32 = 32;
 
-    for(let _:u32 := 0; _ < 23; _++){
+    for(let _:u32 = 0; _ < 23; _++){
 		@tester(a--);
 	}
 

--- a/oc/test_files/test_prog2.ol
+++ b/oc/test_files/test_prog2.ol
@@ -1,7 +1,7 @@
 
 fn test_func() -> i32 {
-	let mut i:u32 := 232;
-	let mut j:u32 := 32;
+	let mut i:u32 = 232;
+	let mut j:u32 = 32;
 
 	defer {
 	i++;
@@ -9,13 +9,13 @@ fn test_func() -> i32 {
 
 	while(i >= 232) {
 		if(i == 2) { 
-			i := i + 2;
+			i = i + 2;
 			ret i;
 		} else if(i == 3)  {
-			i := 32;
+			i = 32;
 			//ret i;
 		} else {
-			i := i + 1;
+			i = i + 1;
 			ret i;
 		}
 	}
@@ -38,8 +38,8 @@ fn test_func() -> i32 {
 		//ret i;
 	} while (i < 232);
 
-	let sample:u32 := 2232;
-	for(let i:u32 := 0; i < 2323; i++) {
+	let sample:u32 = 2232;
+	for(let i:u32 = 0; i < 2323; i++) {
 		@test_func();
 		if(i == -1) {
 			ret -1;
@@ -47,29 +47,29 @@ fn test_func() -> i32 {
 
 	}
 
-	let my_int:i32 := -2;
+	let my_int:i32 = -2;
 	ret 32;
 }
 
 pub fn main(argc:i32, argv:char**)->i32{
-	let i:u32 := 0;
-	let mut a:u32 := 0;
-	let v:u32 := 0;
-	let b:u32 := 0;
-	let j:u32 := 0;
-	let sadf:u32 := 0;
+	let i:u32 = 0;
+	let mut a:u32 = 0;
+	let v:u32 = 0;
+	let b:u32 = 0;
+	let j:u32 = 0;
+	let sadf:u32 = 0;
 
 	if(i == 0)  {
 		if(j == a) {
-			a := 3;	
+			a = 3;	
 		} else if (j > a)  {
 			ret j;
 		}
 	} else if( i == 1) {
-		let i_copy:u32 := i;
+		let i_copy:u32 = i;
 	} else {
 		@test_func();
-		let j_copy:u32 := i;
+		let j_copy:u32 = i;
 	}
 
 	defer {

--- a/oc/test_files/test_prog3.ol
+++ b/oc/test_files/test_prog3.ol
@@ -2,7 +2,7 @@
 
 /*
 fn my_fn() -> void{
-	let i:u32 := 32;
+	let i:u32 = 32;
 }
 */
 
@@ -12,37 +12,37 @@ fn test(argc:i32, argv:char**) -> i32{
 	declare mut c:u32;
 	declare mut d:u32;
 
-	a := 32;
-	b := 27;
-	c := 23;
-	d := 22;
+	a = 32;
+	b = 27;
+	c = 23;
+	d = 22;
 
-	a := (a+b) & (b << 2) * (c+d);
+	a = (a+b) & (b << 2) * (c+d);
 
 
 	if(a >= 2) {
-		a := a + 3;
+		a = a + 3;
 	} else if (a == 2) {
-		a := a + 2;
+		a = a + 2;
 	} else {
-		a := a + 1;
+		a = a + 1;
 	}
 
 
 	//do{
 	//while(d >= 32) {
-	for(let mut i:u32 := 0; i < 323; i++) {
+	for(let mut i:u32 = 0; i < 323; i++) {
 		declare a:u32;
 		declare b:u32;
 		declare c:u32;
 
-		a := 32;
-		b := 27;
-		c := 23;
+		a = 32;
+		b = 27;
+		c = 23;
 
 	};// while(d >= 32);
 
-	let abcd:u32 := 322;
+	let abcd:u32 = 322;
 
 	ret a;
 }

--- a/oc/test_files/test_prog4.ol
+++ b/oc/test_files/test_prog4.ol
@@ -3,23 +3,23 @@
 */
 
 fn my_func(mut i:u32, mut j:u32) -> i32{
-	i := i + 1;
+	i = i + 1;
 	ret i;
 }
 
 
 fn my_fn(mut argc:i32, mut argv:char**)->i32{
-	let mut i:i32 := 0;
-	let mut a:i32 := 0;
-	let v:i32 := 0;
-	let b:i32 := 0;
-	let j:i32 := 0;
-	let sadf:i32 := 0;
+	let mut i:i32 = 0;
+	let mut a:i32 = 0;
+	let v:i32 = 0;
+	let b:i32 = 0;
+	let j:i32 = 0;
+	let sadf:i32 = 0;
 
 	declare abcd:char*;
-	let ex:char := 'c';
+	let ex:char = 'c';
 
-	**argv := ~ex;
+	**argv = ~ex;
 
 	--argv;
 	
@@ -28,28 +28,28 @@ fn my_fn(mut argc:i32, mut argv:char**)->i32{
 		idle;
 		idle;
 		if(i <= 0)  {
-			a := a + 1;
+			a = a + 1;
 		} else if( i == 1) {
-			a := 23232;
+			a = 23232;
 			if(a == 3232) {
-				a := a + 1;
+				a = a + 1;
 			} else {
-				a := a + 2;
+				a = a + 2;
 			}
 		} else {
-			a := 0x23a;
+			a = 0x23a;
 		}
 
 		//Just some junk
-		let sadfa:i32 := 232;
+		let sadfa:i32 = 232;
 
-		a := a + 323;
+		a = a + 323;
 	}
 	
 
 	@my_func(i+2, j);
 
-	let j_copy:u32 := -i * 32 - 322;
+	let j_copy:u32 = -i * 32 - 322;
 	++j_copy;
 
 	ret j + a;

--- a/oc/test_files/test_prog5.ol
+++ b/oc/test_files/test_prog5.ol
@@ -3,27 +3,27 @@
  * as opposed to creating a positive or negative overflow
 fn saturating_add(x:i32, y:i32) -> i32{
 	//Find the regular sum
-	let mut sum:i32 := x + y;
+	let mut sum:i32 = x + y;
 
 	//To find the size of the int in bytes(I don't want to assume it's 32 always), 
 	//multiply by 8 by shifting right by 3(*2 *2 *2)
-	let mut num_bits:i32 := 4 << 3;
+	let mut num_bits:i32 = 4 << 3;
 	
 	//For utility, get an int where we have 1000...000
-	let mut one_as_msb:i32 := 1 << (num_bits - 1);
+	let mut one_as_msb:i32 = 1 << (num_bits - 1);
 
 	//If x y have the same sign, XORing will cause the MSB to be 0
 	//and inverting it will make it 1 if they do
-	let mut x_y_same_sign:i32 := ~(x ^ y);
+	let mut x_y_same_sign:i32 = ~(x ^ y);
 
 	//Now we can determine if x and the sum have different signs
 	//using the same process, XORing will put 1 in the MSB if they do
-	let mut x_sum_different_sign:i32 := x ^ sum;
+	let mut x_sum_different_sign:i32 = x ^ sum;
 
-	let mut was_overflow:i32 := (x_y_same_sign & x_sum_different_sign) >> (num_bits - 1);
+	let mut was_overflow:i32 = (x_y_same_sign & x_sum_different_sign) >> (num_bits - 1);
 
 
-	let mut maxint_or_minint:i32 := one_as_msb ^ (sum >> (num_bits -1));
+	let mut maxint_or_minint:i32 = one_as_msb ^ (sum >> (num_bits -1));
 
 	ret (~was_overflow & sum) + (was_overflow & maxint_or_minint);
 }
@@ -33,7 +33,7 @@ replace TEST_INT with -1;
 replace my_char with 'c';
 
 fn tester() -> void{
-	let mut x:i32 := !3;
+	let mut x:i32 = !3;
 	++x;
 	ret;
 }
@@ -43,12 +43,12 @@ fn tester() -> void{
  */
 pub fn main() -> i32{
 
-	let mut x:i32 := -2U;
-	let mut my_float:f32 := -0.23;
-	let mut aa:i32 := --3;
-	let mut my_val:i32 := x + -32;
-	let mut teste:i32 := TEST_INT;
-	let test_char:char := my_char;
+	let mut x:i32 = -2U;
+	let mut my_float:f32 = -0.23;
+	let mut aa:i32 = --3;
+	let mut my_val:i32 = x + -32;
+	let mut teste:i32 = TEST_INT;
+	let test_char:char = my_char;
 	jump label1;
 
 	//Example asm inline statement
@@ -77,9 +77,9 @@ pub fn main() -> i32{
 		ret x;
 	}
 	
-	let y:i32 := 32;
+	let y:i32 = 32;
 
-	let f:f32 := 23.2;
+	let f:f32 = 23.2;
 
 	ret 0;
 }

--- a/oc/test_files/test_prog6.ol
+++ b/oc/test_files/test_prog6.ol
@@ -3,27 +3,27 @@
  * as opposed to creating a positive or negative overflow
 fn saturating_add(x:i32, y:i32) -> i32{
 	//Find the regular sum
-	let mut sum:i32 := x + y;
+	let mut sum:i32 = x + y;
 
 	//To find the size of the int in bytes(I don't want to assume it's 32 always), 
 	//multiply by 8 by shifting right by 3(*2 *2 *2)
-	let mut num_bits:i32 := 4 << 3;
+	let mut num_bits:i32 = 4 << 3;
 	
 	//For utility, get an int where we have 1000...000
-	let mut one_as_msb:i32 := 1 << (num_bits - 1);
+	let mut one_as_msb:i32 = 1 << (num_bits - 1);
 
 	//If x y have the same sign, XORing will cause the MSB to be 0
 	//and inverting it will make it 1 if they do
-	let mut x_y_same_sign:i32 := ~(x ^ y);
+	let mut x_y_same_sign:i32 = ~(x ^ y);
 
 	//Now we can determine if x and the sum have different signs
 	//using the same process, XORing will put 1 in the MSB if they do
-	let mut x_sum_different_sign:i32 := x ^ sum;
+	let mut x_sum_different_sign:i32 = x ^ sum;
 
-	let mut was_overflow:i32 := (x_y_same_sign & x_sum_different_sign) >> (num_bits - 1);
+	let mut was_overflow:i32 = (x_y_same_sign & x_sum_different_sign) >> (num_bits - 1);
 
 
-	let mut maxint_or_minint:i32 := one_as_msb ^ (sum >> (num_bits -1));
+	let mut maxint_or_minint:i32 = one_as_msb ^ (sum >> (num_bits -1));
 
 	ret (~was_overflow & sum) + (was_overflow & maxint_or_minint);
 }
@@ -38,7 +38,7 @@ replace TEST_INT with -1;
 replace my_char with 'c';
 
 fn tester() -> void{
-	let mut x:i32 := !3;
+	let mut x:i32 = !3;
 	++x;
 	ret;
 }
@@ -48,12 +48,12 @@ fn tester() -> void{
  */
 pub fn main() -> i32{
 
-	let mut x:i32 := -2U;
-	let mut my_float:f32 := -0.23;
-	let mut aa:i32 := --3;
-	let mut my_val:i32 := x + -32;
-	let mut teste:i32 := TEST_INT;
-	let test_char:char := my_char;
+	let mut x:i32 = -2U;
+	let mut my_float:f32 = -0.23;
+	let mut aa:i32 = --3;
+	let mut my_val:i32 = x + -32;
+	let mut teste:i32 = TEST_INT;
+	let test_char:char = my_char;
 
 	//Example asm inline statement
 	//defer asm{

--- a/oc/test_files/test_prog7.ol
+++ b/oc/test_files/test_prog7.ol
@@ -11,27 +11,27 @@ replace my_char with 'c';
  * as opposed to creating a positive or negative overflow
 fn saturating_add(x:i32, y:i32) -> i32{
 	//Find the regular sum
-	let mut sum:i32 := x + y;
+	let mut sum:i32 = x + y;
 
 	//To find the size of the int in bytes(I don't want to assume it's 32 always), 
 	//multiply by 8 by shifting right by 3(*2 *2 *2)
-	let mut num_bits:i32 := 4 << 3;
+	let mut num_bits:i32 = 4 << 3;
 	
 	//For utility, get an int where we have 1000...000
-	let mut one_as_msb:i32 := 1 << (num_bits - 1);
+	let mut one_as_msb:i32 = 1 << (num_bits - 1);
 
 	//If x y have the same sign, XORing will cause the MSB to be 0
 	//and inverting it will make it 1 if they do
-	let mut x_y_same_sign:i32 := ~(x ^ y);
+	let mut x_y_same_sign:i32 = ~(x ^ y);
 
 	//Now we can determine if x and the sum have different signs
 	//using the same process, XORing will put 1 in the MSB if they do
-	let mut x_sum_different_sign:i32 := x ^ sum;
+	let mut x_sum_different_sign:i32 = x ^ sum;
 
-	let mut was_overflow:i32 := (x_y_same_sign & x_sum_different_sign) >> (num_bits - 1);
+	let mut was_overflow:i32 = (x_y_same_sign & x_sum_different_sign) >> (num_bits - 1);
 
 
-	let mut maxint_or_minint:i32 := one_as_msb ^ (sum >> (num_bits -1));
+	let mut maxint_or_minint:i32 = one_as_msb ^ (sum >> (num_bits -1));
 
 	ret (~was_overflow & sum) + (was_overflow & maxint_or_minint);
 }
@@ -39,7 +39,7 @@ fn saturating_add(x:i32, y:i32) -> i32{
 */
 
 fn tester() -> void{
-	let mut x:i32 := !3;
+	let mut x:i32 = !3;
 	++x;
 	ret;
 }
@@ -49,7 +49,7 @@ fn tester() -> void{
  */
 pub fn main() -> i32{
 
-	let mut x:i32 := -2U;
+	let mut x:i32 = -2U;
 
 	//Example asm inline statement
 	defer {
@@ -64,7 +64,7 @@ pub fn main() -> i32{
 	}
 
 	defer { 
-		x := x + 3;	
+		x = x + 3;	
 		@tester();
 	}
 	
@@ -75,18 +75,18 @@ pub fn main() -> i32{
 		ret x;
 	}
 	
-	let y:i32 := 32;
+	let y:i32 = 32;
 
-	let f:f32 := 23.2;
+	let f:f32 = 23.2;
 
 	//Empty case statement testing
 	switch(x){
 		case 3 ->
 			{
-			x := x + 3;
+			x = x + 3;
 			}
 		default -> {
-			x := x + 76;
+			x = x + 76;
 		}
 	}
 

--- a/oc/test_files/test_prog8.ol
+++ b/oc/test_files/test_prog8.ol
@@ -8,15 +8,15 @@ fn tester(i:u32) -> i32{
  */
 pub fn main() -> i32{
 	
-	let a:i32 := 23;
+	let a:i32 = 23;
 	
  	declare arr:i32[32][3];
 
-	arr[1][2] := 23;
+	arr[1][2] = 23;
 
-	let mut b:i32 := arr[3][2];
+	let mut b:i32 = arr[3][2];
 
-	for(let _:i32 := 0; _ < 838; _++){
+	for(let _:i32 = 0; _ < 838; _++){
 		a++;
 	}
 

--- a/oc/test_files/test_prog9.ol
+++ b/oc/test_files/test_prog9.ol
@@ -8,12 +8,12 @@ fn tester(i:u32) -> i32{
  */
 pub fn main() -> i32{
 	
-	let mut a:i32 := 23;
+	let mut a:i32 = 23;
 	
 	if(a == 32) {
-		let k:i32 := 232332222;
+		let k:i32 = 232332222;
 	} else {
-		let p:i32 := -2322;
+		let p:i32 = -2322;
 	}
 	
 	ret 0;

--- a/oc/test_files/testing_coercion.ol
+++ b/oc/test_files/testing_coercion.ol
@@ -4,9 +4,9 @@
 */
 
 pub fn main(argc:i32, argv:char**) -> i32 {
-	let mut x:i32 := 2;
-	let mut a:u64 := x;
-	let mut y:i8 := 'a';
+	let mut x:i32 = 2;
+	let mut a:u64 = x;
+	let mut y:i8 = 'a';
 
 	if( x > y ) {
 		ret y;

--- a/oc/test_files/testing_logical_and.ol
+++ b/oc/test_files/testing_logical_and.ol
@@ -5,10 +5,10 @@
 */
 
 fn tester() -> u8 {
-	let mut x:u8 := 2;
-	let mut y:u8 := 3;
+	let mut x:u8 = 2;
+	let mut y:u8 = 3;
 
-	let mut z:u8 := x && y;
+	let mut z:u8 = x && y;
 
 	ret z;
 }

--- a/oc/test_files/testing_to_long_conversion.ol
+++ b/oc/test_files/testing_to_long_conversion.ol
@@ -5,21 +5,21 @@
 */
 
 fn test_subtraction() -> u64 {
-	let mut y:u64 := 32;
-	let mut x:i16 := 3;
+	let mut y:u64 = 32;
+	let mut x:i16 = 3;
 
-	y := y - x;
-	y := y * x;
-	y := y % x;
+	y = y - x;
+	y = y * x;
+	y = y % x;
 	ret y;
 }
 
 
 fn test() -> u64 {
-	let mut y:u64 := 32;
-	let mut x:i32 := 3;
+	let mut y:u64 = 32;
+	let mut x:i32 = 3;
 
-	y := y + x;
+	y = y + x;
 	ret y;
 }
 

--- a/oc/test_files/testing_void_declaration.ol
+++ b/oc/test_files/testing_void_declaration.ol
@@ -5,35 +5,35 @@
 
 
 pub fn main(void) -> i32{
-	let mut x:i32 := 32;
+	let mut x:i32 = 32;
 
 	switch(x){
 		case 2 -> {
-			x := 32;
+			x = 32;
 		}
 		case 1 -> {
-			x := -3;
+			x = -3;
 		}
 		case 4 -> {}
 		case 3 -> {
-			x := 211;
+			x = 211;
 		}
 
 		case 6 -> {
-			x := 22;
+			x = 22;
 		}
 
 		default -> {
-			x := x - 22;
+			x = x - 22;
 		}
 	}
 
 	switch(x){
 		default -> {
-			let i:i32 := 2;
+			let i:i32 = 2;
 		}
 		case 2 -> {
-			let i:i32 := 3;
+			let i:i32 = 3;
 		}
 	}
 	

--- a/oc/test_files/type_conversion_small_large.ol
+++ b/oc/test_files/type_conversion_small_large.ol
@@ -21,13 +21,13 @@ pub fn test_unions() -> i32{
 	//Get x as a struct
 	declare mut x:custom_struct;
 
-	x:tester.ch := 'a';
+	x:tester.ch = 'a';
 
-	x:tester.x[2] := 2;
-	x:tester.x[3] := 2;
-	x:tester.x[4] := 2;
+	x:tester.x[2] = 2;
+	x:tester.x[3] = 2;
+	x:tester.x[4] = 2;
 
-	x:a := 'a';
+	x:a = 'a';
 
 	ret x:a + x:tester.x[3];
 }
@@ -36,7 +36,7 @@ pub fn test_array_in_union() -> i32{
 	declare my_union:custom_union;
 	
 	//Store x
-	my_union.x[2] := 32;
+	my_union.x[2] = 32;
 	
 	//Read as char
 	ret my_union.ch + my_union.x[3];
@@ -48,7 +48,7 @@ pub fn main(argc:i32, argv:char**) -> i32 {
 		y:char;
 	} as my_struct;
 
-	let custom:my_struct := {5, 'a'};
+	let custom:my_struct = {5, 'a'};
 
 	//Should be casted to an int
 	ret custom:y + custom:x;

--- a/oc/test_files/type_testing.ol
+++ b/oc/test_files/type_testing.ol
@@ -1,9 +1,9 @@
 pub fn main() -> i32 {
-	let mut x:u32 := 2;
-	let mut y:i32 := 3;
-	let mut k:char := 'a';
+	let mut x:u32 = 2;
+	let mut y:i32 = 3;
+	let mut k:char = 'a';
 
-	let mut a:i32 := x * k ;
+	let mut a:i32 = x * k ;
 
 	ret a;
 }

--- a/oc/test_files/union_in_struct.ol
+++ b/oc/test_files/union_in_struct.ol
@@ -21,13 +21,13 @@ pub fn main() -> i32{
 	//Get x as a struct
 	declare mut x:custom_struct;
 
-	x:tester.ch := 'a';
+	x:tester.ch = 'a';
 
-	x:tester.x[2] := 2;
-	x:tester.x[3] := 2;
-	x:tester.x[4] := 2;
+	x:tester.x[2] = 2;
+	x:tester.x[3] = 2;
+	x:tester.x[4] = 2;
 
-	x:a := 'a';
+	x:a = 'a';
 
 	ret x:a + x:tester.x[3];
 }

--- a/oc/test_files/union_pointer.ol
+++ b/oc/test_files/union_pointer.ol
@@ -11,8 +11,8 @@ define union my_union {
 } as custom_union;
 
 pub fn mut_union(mut x:custom_union*) -> i32 {
-	(*x).x := 4;
-	(*x).y := 2;
+	(*x).x = 4;
+	(*x).y = 2;
 
 	ret (*x).x;
 }
@@ -22,7 +22,7 @@ pub fn main() -> i32{
 	declare my_union:custom_union;
 	
 	//Store x
-	my_union.x := 32;
+	my_union.x = 32;
 
 	@mut_union(&my_union);
 	

--- a/oc/test_files/union_pointer_access.ol
+++ b/oc/test_files/union_pointer_access.ol
@@ -12,8 +12,8 @@ define union my_union {
 
 pub fn mut_union(mut x:custom_union*) -> i32 {
 	//We'll use the special union pointer accessor here
-	x->x := 4;
-	x->y := 2;
+	x->x = 4;
+	x->y = 2;
 
 	ret x->x;
 }
@@ -23,7 +23,7 @@ pub fn main() -> i32{
 	declare my_union:custom_union;
 	
 	//Store x
-	my_union.x := 32;
+	my_union.x = 32;
 
 	@mut_union(&my_union);
 	

--- a/oc/test_files/user_defined_enum.ol
+++ b/oc/test_files/user_defined_enum.ol
@@ -12,26 +12,26 @@ define enum my_enum {
 } as custom_enum;
 
 fn tester(mut param:custom_enum) -> i32{
-	let mut x:i32 := 32;
+	let mut x:i32 = 32;
 
 	switch(param){
 		case A -> {
-			x := 32;
+			x = 32;
 		}
 		case B -> {
-			x := -3;
+			x = -3;
 		}
 		case C -> {}
 		case D -> {
-			x := 211;
+			x = 211;
 		}
 
 		case E -> {
-			x := 22;
+			x = 22;
 		}
 
 		default -> {
-			x := x - 22;
+			x = x - 22;
 		}
 	}
 

--- a/oc/test_files/variable_conditional_check.ol
+++ b/oc/test_files/variable_conditional_check.ol
@@ -4,7 +4,7 @@
 */
 
 pub fn main(argc:i32, argv:char**) -> i32 {
-	let mut x:i32 := 232;
+	let mut x:i32 = 232;
 
 	//Checking while
 	while(*argv){


### PR DESCRIPTION
Replace := with =: we may one day want to use the := operator for something different. We'll replace it now with regular = to simplify the syntax and typing experience.

Closes #273 