### PR TITLE
[Emergency Fix]: Fix issue where struct pointer access of first member causes invalid dereferencing

### DIFF
--- a/oc/compiler/instruction_selector/instruction_selector.c
+++ b/oc/compiler/instruction_selector/instruction_selector.c
@@ -3550,8 +3550,15 @@ static u_int8_t simplify_window(cfg_t* cfg, instruction_window_t* window){
 				//We also can't combine these
 				&& !(second->op1->indirection_level > 0 && first->op1->indirection_level > 0)){
 
-				//Copy this over so we don't lose it
-				first->op1->indirection_level += second->op1->indirection_level;
+				//If this is more than 0, we'll need to emit a copy of the first variable
+				//so that modifying it does not mess with any other instances of said variable
+				if(second->op1->indirection_level > 0){
+					//Emit an exact copy
+					first->op1 = emit_var_copy(first->op1);
+
+					//Copy over the indirection levels
+					first->op1->indirection_level = second->op1->indirection_level;
+				}
 
 				//Manage our use state here
 				replace_variable(second->op1, first->op1);

--- a/oc/test_files/struct_pointer_access.ol
+++ b/oc/test_files/struct_pointer_access.ol
@@ -1,0 +1,34 @@
+/**
+* Author: Jack Robbins
+* This program is made for the purposes of testing struct pointers
+*/
+
+/**
+* Size should be: 1 + 3 pad + 12 + 1 + 3 pad = 20
+*/
+define struct my_struct{
+	mut ch:char;
+	mut y:i32[3];
+	mut lch:char;
+} as custom_struct;
+
+
+/**
+* A function that will mutate a structure in its entirety
+*/
+pub fn mutate_structure_pointer(mut struct_pointer:custom_struct*) -> i32 {
+	//Should cause issue
+	ret struct_pointer=>ch;
+}
+
+
+pub fn main(arg:i32, argv:char**) -> i32{
+	//Declare and initialize a struct
+	let mut a:custom_struct = {'a', [2,3,4], 'b'};
+
+	//Call the mutator
+	@mutate_structure_pointer(&a);
+
+	//Grab the value from the internal array argument
+	ret a:y[1];
+}


### PR DESCRIPTION
Fix issue where struct pointer access of first member causes invalid dereferencing

Closes #301 