### PR TITLE
[Triaged Fix]: Dynamic array no longer generates buffer overflow errors

### DIFF
--- a/oc/compiler/utils/dynamic_array/dynamic_array.c
+++ b/oc/compiler/utils/dynamic_array/dynamic_array.c
@@ -234,7 +234,7 @@ void* dynamic_array_delete_at(dynamic_array_t* array, u_int16_t index){
 	}
 
 	//Null this out
-	array->internal_array[array->current_index] = NULL;
+	array->internal_array[array->current_index - 1] = NULL;
 
 	//We've seen one less of these now
 	(array->current_index)--;


### PR DESCRIPTION
[Triaged Fix]: Dynamic array no longer generates buffer overflow errors

The issue was caused by a write to array->internal_array[array->current_index]. The current_index is the *next* index that we write to, not the last real index. In certain cases, this index is actually above the byte size and as such we need to realloc, but the delete function does not know that.

This is resolved by simply nulling out current_index-1 instead, which is the correct target.

Closes #414 