### PR TITLE
[Compiler Utilities]: The heap_queue_t has been rewritten to use an underlying circular queue

### DIFF
--- a/oc/compiler/utils/queue/heap_queue.c
+++ b/oc/compiler/utils/queue/heap_queue.c
@@ -13,6 +13,7 @@
 #include "heap_queue.h"
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <sys/types.h>
 #include "../constants.h"
 
@@ -109,6 +110,20 @@ void* dequeue(heap_queue_t* heap_queue){
 
 	//And give back their data
 	return data;
+}
+
+
+/**
+ * Completely wipe the existing memory of the heap queue. This is
+ * done if we wish to reuse it
+ */
+void heap_queue_clear(heap_queue_t* heap_queue){
+	//Wipe out these two values
+	heap_queue->front = 0;
+	heap_queue->num_elements = 0;
+
+	//Wipe out the entire pointer array
+	memset(heap_queue->data, NULL, heap_queue->capacity * sizeof(void*));
 }
 
 

--- a/oc/compiler/utils/queue/heap_queue.c
+++ b/oc/compiler/utils/queue/heap_queue.c
@@ -6,6 +6,7 @@
 
 #include "heap_queue.h"
 #include <stdlib.h>
+#include <stdio.h>
 #include <sys/types.h>
 //For the TRUE and FALSE constants
 #include "../constants.h"
@@ -27,7 +28,7 @@ heap_queue_t heap_queue_alloc(){
 	//Dynamically allocate the underlying array
 	queue.data = calloc(queue.capacity, sizeof(void*));
 
-	//Initially the front is at -1
+	//Front being -1 is a flag that we're 0
 	queue.front = -1;
 
 	return queue;
@@ -38,31 +39,22 @@ heap_queue_t heap_queue_alloc(){
  * Enqueue a node into the queue
  */
 void enqueue(heap_queue_t* heap_queue, void* data){
-	//If the data is NULL, we just don't add anything
-	if(data == NULL || heap_queue == NULL){
-		return;
+	//Fail out if this happens
+	if(data == NULL){
+		fprintf(stderr, "Attempt to insert NULL into a heap queue");
+		exit(1);
 	}
 
-	//To enqueue, we first need a new node
-	heap_queue_node_t* node = calloc(1, sizeof(heap_queue_node_t));
-
-	//This node stores our data
-	node->data = data;
-	
-	//Special case -- this is the very first node
-	if(heap_queue->head == NULL){
-		heap_queue->head = node;
-		heap_queue->tail = node;
-	//Otherwise, we have to add to the end
-	} else {
-		//Add this in
-		heap_queue->tail->next = node;
-		//He now is the tail
-		heap_queue->tail = node;
+	/**
+	 * Dynamic resize condition - we will overflow the queue if we do this
+	 * so we need to resize
+	 *
+	 * TODO RESIZE ISN'T so simple
+	 */
+	if(heap_queue->num_elements == heap_queue->capacity){
 	}
 
-	//We have one more node, so
-	heap_queue->num_nodes++;
+
 }
 
 
@@ -96,11 +88,12 @@ void* dequeue(heap_queue_t* heap_queue){
 	return data;
 }
 
+
 /**
- * Determine if the heap is empty
+ * Determine if the queue is empty
  */
 u_int8_t queue_is_empty(heap_queue_t* heap_queue){
-	return heap_queue->num_nodes == 0 ? TRUE : FALSE;
+	return heap_queue->num_elements == 0 ? TRUE : FALSE;
 }
 
 

--- a/oc/compiler/utils/queue/heap_queue.c
+++ b/oc/compiler/utils/queue/heap_queue.c
@@ -15,39 +15,22 @@
  * heap structure will be allocated to the stack
  */
 heap_queue_t heap_queue_alloc(){
-	//First we allocate it
+	//Stack allocate the queue
 	heap_queue_t queue;
 
-	//We currently have nothing
-	queue.num_nodes = 0;
+	//Initially no elements
+	queue.num_elements = 0;
 
-	//These are both initially NULL
-	queue.head = NULL;
-	queue.tail = NULL;
+	//Use the default capacity
+	queue.capacity = HEAP_QUEUE_DEFAULT_CAPACITY;
 
-	//And we're done, just return it
+	//Dynamically allocate the underlying array
+	queue.data = calloc(queue.capacity, sizeof(void*));
+
+	//Initially the front is at -1
+	queue.front = -1;
+
 	return queue;
-}
-
-
-/**
- * Deallocate an entire heap queue structure
- *
- * NOTE: Only the nodes are freed, not the underlying data
- */
-void heap_queue_dealloc(heap_queue_t* heap_queue){
-	//Grab a cursor to use
-	heap_queue_node_t* cursor = heap_queue->head;
-	heap_queue_node_t* temp;
-
-	//We run through the whole list freeing node by node
-	while(cursor != NULL){
-		temp = cursor;
-		//Advance cursor
-		cursor = cursor->next;
-		//Free this
-		free(temp);
-	}
 }
 
 
@@ -118,4 +101,18 @@ void* dequeue(heap_queue_t* heap_queue){
  */
 u_int8_t queue_is_empty(heap_queue_t* heap_queue){
 	return heap_queue->num_nodes == 0 ? TRUE : FALSE;
+}
+
+
+/**
+ * Deallocate the heap queue data structure
+ */
+void heap_queue_dealloc(heap_queue_t* heap_queue){
+	//Free the data
+	free(heap_queue->data);
+
+	//Reset everything else
+	heap_queue->front = -1;
+	heap_queue->capacity = 0;
+	heap_queue->num_elements = 0;
 }

--- a/oc/compiler/utils/queue/heap_queue.c
+++ b/oc/compiler/utils/queue/heap_queue.c
@@ -42,6 +42,53 @@ heap_queue_t heap_queue_alloc(){
 
 
 /**
+ * Dynamically resize the heap queue as needed. This is not
+ * as simple as many other data structures because we need to copy the
+ * data in the correct order
+ *
+ * Procedure resize:
+ * 	new_capacity = old_capacity * 2
+ * 	new_data = allocate new data
+ *
+ * 	for i in range num_elements:
+ *  	int index = (front + i) % old_capacity
+ *  	new_data[i] = old_data[index]
+ *
+ * 	front = 0
+ *  capacity = new_capacity
+ *  data = new_data
+ */
+static inline void resize(heap_queue_t* queue){
+	//New capacity is double the old one(maintain powers of 2)
+	u_int32_t new_capacity = queue->capacity * 2;
+	//Allocate a fresh array
+	void** new_data = calloc(new_capacity, sizeof(void*));
+
+	/**
+	 * Copy over each element in the correct order starting at the
+	 * front index of the old queue
+	 */
+	for(u_int32_t i = 0; i < queue->num_elements; i++){
+	 	//Get the index of the "i"th element the old way
+	 	int32_t index = (queue->front + i) % queue->capacity;
+
+		//Now new_data[i] = this old data. It will be in the right order
+		new_data[i] = queue->data[index];
+	}
+
+	//Destroy the old buffer
+	free(queue->data);
+
+	//Front is at 0 after our copy
+	queue->front = 0;
+	//Capacity is new
+	queue->capacity = new_capacity;
+	//Data is new now too
+	queue->data = new_data;
+}
+
+
+/**
  * Enqueue a node into the queue.
  * Algorithm for circular queue enqueue:
  *
@@ -62,11 +109,9 @@ void enqueue(heap_queue_t* heap_queue, void* data){
 	/**
 	 * Dynamic resize condition - we will overflow the queue if we do this
 	 * so we need to resize
-	 *
-	 * TODO RESIZE ISN'T so simple
 	 */
 	if(heap_queue->num_elements == heap_queue->capacity){
-		//TODO
+		resize(heap_queue);
 	}
 
 	/**

--- a/oc/compiler/utils/queue/heap_queue.c
+++ b/oc/compiler/utils/queue/heap_queue.c
@@ -34,8 +34,8 @@ heap_queue_t heap_queue_alloc(){
 	//Dynamically allocate the underlying array
 	queue.data = calloc(queue.capacity, sizeof(void*));
 
-	//Front being -1 is a flag that we're 0
-	queue.front = -1;
+	//Front is just the front of the array
+	queue.front = 0;
 
 	return queue;
 }
@@ -168,7 +168,7 @@ void heap_queue_clear(heap_queue_t* heap_queue){
 	heap_queue->num_elements = 0;
 
 	//Wipe out the entire pointer array
-	memset(heap_queue->data, NULL, heap_queue->capacity * sizeof(void*));
+	memset(heap_queue->data, 0, heap_queue->capacity * sizeof(void*));
 }
 
 

--- a/oc/compiler/utils/queue/heap_queue.c
+++ b/oc/compiler/utils/queue/heap_queue.c
@@ -5,13 +5,15 @@
  * Conceptually, a circular queue can wrap around itself to avoid the need to shift. We maintain the
  * index of the front and we can always calculate the rear by doing rear = (front + num_elements) % size
  *
-*/
+ * This queue will dynamically resize as needed, but only upwards. We will never downsize the queue
+ * as this is just wasteful. A couple dozen extra bytes allocated is fine so long as it saves us the trouble
+ * of reallocating
+ */
 
 #include "heap_queue.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <sys/types.h>
-//For the TRUE and FALSE constants
 #include "../constants.h"
 
 /**
@@ -84,30 +86,28 @@ void enqueue(heap_queue_t* heap_queue, void* data){
 /**
  * Dequeue from the queue(take from the head)
  *
- * Returns NULL if there was an error or empty queue
-*/
+ * Algorithm for a circular queue:
+ * 
+ * data = queue->underlying[front_index]
+ * front_index = (front_index + 1) % capacity
+ * num_elements--
+ */
 void* dequeue(heap_queue_t* heap_queue){
-	//Let's just check to save ourselves here
-	if(heap_queue == NULL || heap_queue->head == NULL){
-		return NULL;
-	}
+	//Grab the data out first
+	void* data = heap_queue->data[heap_queue->front];
 
-	//Grab a reference to the head
-	heap_queue_node_t* head = heap_queue->head;
+	/**
+	 * Recompute the front by adding 1 and then using the capacity to perform
+	 * our wrap around procedure. This is important to ensure that we aren't
+	 * overrunning the bounds of our buffer and is how this queue gets the
+	 * circular name
+	 */
+	heap_queue->front = (heap_queue->front + 1) % heap_queue->capacity;
 
-	//Grab the data
-	void* data = head->data;
-	
-	//Advance this up now
-	heap_queue->head = head->next;
+	//Size went done
+	heap_queue->num_elements--;
 
-	//Free the old head
-	free(head);
-
-	//We've one less node now
-	heap_queue->num_nodes--;
-
-	//And give back the data
+	//And give back their data
 	return data;
 }
 

--- a/oc/compiler/utils/queue/heap_queue.c
+++ b/oc/compiler/utils/queue/heap_queue.c
@@ -1,7 +1,10 @@
 /**
  * Author: Jack Robbins
  *
- * Implementation file for the heap allocated queue datastructure util
+ * Implementation file for the heap allocated queue data structure. We use a circular queue for this.
+ * Conceptually, a circular queue can wrap around itself to avoid the need to shift. We maintain the
+ * index of the front and we can always calculate the rear by doing rear = (front + num_elements) % size
+ *
 */
 
 #include "heap_queue.h"
@@ -36,7 +39,15 @@ heap_queue_t heap_queue_alloc(){
 
 
 /**
- * Enqueue a node into the queue
+ * Enqueue a node into the queue.
+ * Algorithm for circular queue enqueue:
+ *
+ * 	if capacity == num_elements:
+ * 		resize
+ *
+ * 	int rear = (front + num_elements) % capacity
+ * 	queue->data[rear] = new_data
+ * 	num_elements++
  */
 void enqueue(heap_queue_t* heap_queue, void* data){
 	//Fail out if this happens
@@ -52,9 +63,21 @@ void enqueue(heap_queue_t* heap_queue, void* data){
 	 * TODO RESIZE ISN'T so simple
 	 */
 	if(heap_queue->num_elements == heap_queue->capacity){
+		//TODO
 	}
 
+	/**
+	 * Calculate the rear index by doing (front + element_count) % capacity. This will wrap
+	 * us around the front of the array by doing %capacity which is where the circular name
+	 * comes from
+	 */
+	int32_t rear_index = (heap_queue->front + heap_queue->num_elements) % heap_queue->capacity;
 
+	//Store the pointer at the new index
+	heap_queue->data[rear_index] = data;
+
+	//Bump the size for the next go around
+	heap_queue->num_elements++;
 }
 
 

--- a/oc/compiler/utils/queue/heap_queue.h
+++ b/oc/compiler/utils/queue/heap_queue.h
@@ -11,25 +11,21 @@
 
 //The overall structure itself
 typedef struct heap_queue_t heap_queue_t;
-//A struct for each heapqueue node
-typedef struct heap_queue_node_t heap_queue_node_t;
 
-//The overall heap struct
+/**
+ * The heap queue uses a circular queue data structure. To maintain this
+ * we'll need the data itself, a front index value, a capacity and a size
+ */
 struct heap_queue_t{
-	//The head and tail
-	heap_queue_node_t* head;
-	heap_queue_node_t* tail;
-	u_int32_t num_nodes;
-};
-
-//Heap queue node struct
-struct heap_queue_node_t{
-	//The next node
-	heap_queue_node_t* next;
-	//The data that we store
+	//Data array
 	void* data;
+	//Rear index
+	int32_t front;
+	//How many elements are there in the queue
+	u_int32_t size;
+	//Maximum capacity
+	u_int32_t capacity;
 };
-
 
 /**
  * Allocate a heap queue structure. The overall

--- a/oc/compiler/utils/queue/heap_queue.h
+++ b/oc/compiler/utils/queue/heap_queue.h
@@ -60,7 +60,7 @@ void enqueue(heap_queue_t* heap_queue, void* data);
 void* dequeue(heap_queue_t* heap_queue);
 
 /**
- * Determine if the heap is empty. Returns 1 if empty, 0 if not
+ * Determine if the queue is empty
  */
 u_int8_t queue_is_empty(heap_queue_t* heap_queue);
 

--- a/oc/compiler/utils/queue/heap_queue.h
+++ b/oc/compiler/utils/queue/heap_queue.h
@@ -41,13 +41,6 @@ struct heap_queue_t{
 heap_queue_t heap_queue_alloc();
 
 /**
- * Deallocate an entire heap queue structure
- *
- * NOTE: Only the nodes are freed, not the underlying data
- */
-void heap_queue_dealloc(heap_queue_t* heap_queue);
-
-/**
  * Enqueue a node into the queue
  */
 void enqueue(heap_queue_t* heap_queue, void* data);
@@ -63,5 +56,18 @@ void* dequeue(heap_queue_t* heap_queue);
  * Determine if the queue is empty
  */
 u_int8_t queue_is_empty(heap_queue_t* heap_queue);
+
+/**
+ * Completely wipe the existing memory of the heap queue. This is
+ * done if we wish to reuse it
+ */
+void heap_queue_clear(heap_queue_t* heap_queue);
+
+/**
+ * Deallocate an entire heap queue structure
+ *
+ * NOTE: Only the nodes are freed, not the underlying data
+ */
+void heap_queue_dealloc(heap_queue_t* heap_queue);
 
 #endif /* HEAP_QUEUE_H */

--- a/oc/compiler/utils/queue/heap_queue.h
+++ b/oc/compiler/utils/queue/heap_queue.h
@@ -9,8 +9,15 @@
 
 #include <sys/types.h>
 
+/**
+ * The capacity starts off at 16 and is doubled every time, meaning
+ * that we've always got a power of 2 as our queue size
+ */
+#define HEAP_QUEUE_DEFAULT_CAPACITY 16
+
 //The overall structure itself
 typedef struct heap_queue_t heap_queue_t;
+
 
 /**
  * The heap queue uses a circular queue data structure. To maintain this
@@ -22,8 +29,8 @@ struct heap_queue_t{
 	//Rear index
 	int32_t front;
 	//How many elements are there in the queue
-	u_int32_t size;
-	//Maximum capacity
+	u_int32_t num_elements;
+	//Maximum capacity(this is what is resized)
 	u_int32_t capacity;
 };
 

--- a/oc/compiler/utils/queue/heap_queue.h
+++ b/oc/compiler/utils/queue/heap_queue.h
@@ -25,7 +25,7 @@ typedef struct heap_queue_t heap_queue_t;
  */
 struct heap_queue_t{
 	//Data array
-	void* data;
+	void** data;
 	//Rear index
 	int32_t front;
 	//How many elements are there in the queue


### PR DESCRIPTION
[Compiler Utilities]: The heap_queue_t has been rewritten to use an underlying circular queue. This greatly reduces our amount of memory allocation and allows for us to operate more efficiently. It probably should have just been a circular queue from the start.

Closes #802 
Closes #803 