### PR TITLE
[Parser]: parser can now recognize and reorder eligible expressions to guarantee that the constant is in the right hand side always

### DIFF
--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -210,6 +210,15 @@ static inline u_int8_t is_copy_assignment_required(generic_type_t* destination_t
  */
 static inline u_int8_t is_type_commutative_for_operation(generic_type_t* type, ollie_token_t op){
 	switch(op){
+		/**
+		 * For multiplication, any type that is *not* a float is commutative
+		 */
+		case STAR:
+			if(IS_FLOATING_POINT(type) == TRUE){
+				return FALSE;
+			}
+
+			return TRUE;
 
 
 		//By defualt - we're assuming this operator is not commutative
@@ -4570,23 +4579,31 @@ static generic_ast_node_t* multiplicative_expression(ollie_token_stream_t* token
 		 * If we are multiplying *and* the type is commutative, we will 
 		 * perform reordering here if need be
 		 */
-		if(op.tok == STAR) {
+		if(is_type_commutative_for_operation(return_type, op.tok) == TRUE
+			&& temp_holder->ast_node_type == AST_NODE_TYPE_CONSTANT){
+			//We'll now swap these two nodes so that the constant is on the right
+			add_child_node(sub_tree_root, right_child);
+			add_child_node(sub_tree_root, temp_holder);
 
+		/**
+		 * Otherwise all is normal so the temp holder goes on the left,
+		 * right child on the right
+		 */
+		} else {
+			add_child_node(sub_tree_root, temp_holder);
+			add_child_node(sub_tree_root, right_child);
 		}
-
 
 		//We'll now assign the binary expression it's operator
 		sub_tree_root->binary_operator = lookahead.tok;
 
-		//Add these both in in order
-		add_child_node(sub_tree_root, temp_holder);
-		add_child_node(sub_tree_root, right_child);
-
 		//Assign the node type
 		sub_tree_root->inferred_type = return_type;
 
-		//By the end of this, we always have a proper subtree with the operator as the root, being held in 
-		//"sub-tree root". We'll now refresh the token to keep looking
+		/**
+		 * By the end of this, we always have a proper subtree with the operator as the root, being held in 
+		 * "sub-tree root". We'll now refresh the token to keep looking
+		 */
 		lookahead = get_next_token(token_stream, &parser_line_num);
 	}
 

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -4658,8 +4658,6 @@ static generic_ast_node_t* multiplicative_expression(ollie_token_stream_t* token
  *  4.) Unsigned will always dominate signed
  *
  * BNF Rule: <additive-expression> ::= <multiplicative-expression>{ (+ | -) <multiplicative-expression>}*
- *
- * TODO HERE
  */
 static generic_ast_node_t* additive_expression(ollie_token_stream_t* token_stream, side_type_t side){
 	//Lookahead token
@@ -5203,8 +5201,6 @@ static generic_ast_node_t* relational_expression(ollie_token_stream_t* token_str
  * always return a pointer to the subtree, whether that subtree is made here or elsewhere
  *
  * BNF Rule: <equality-expression> ::= <relational-expression>{ (==|!=) <relational-expression> }*
- *
- * TODO HERE
  */
 static generic_ast_node_t* equality_expression(ollie_token_stream_t* token_stream, side_type_t side){
 	//Lookahead token
@@ -5366,8 +5362,6 @@ static generic_ast_node_t* equality_expression(ollie_token_stream_t* token_strea
  * at a rule lower down on the tree
  *
  * BNF Rule: <and-expression> ::= <equality-expression>{& <equality-expression>}* 
- *
- * TODO HERE
  */
 static generic_ast_node_t* and_expression(ollie_token_stream_t* token_stream, side_type_t side){
 	//Lookahead token
@@ -5513,8 +5507,6 @@ static generic_ast_node_t* and_expression(ollie_token_stream_t* token_stream, si
  * the chain
  *
  * BNF Rule: <exclusive-or-expression> ::= <and-expression>{^ <and-expression}*
- *
- * TODO HERE
  */
 static generic_ast_node_t* exclusive_or_expression(ollie_token_stream_t* token_stream, side_type_t side){
 	//Lookahead token
@@ -5617,9 +5609,24 @@ static generic_ast_node_t* exclusive_or_expression(ollie_token_stream_t* token_s
 		//We'll now assign the binary expression it's operator
 		sub_tree_root->binary_operator = lookahead.tok;
 
-		//Add both children in order now that everything is valid
-		add_child_node(sub_tree_root, temp_holder);
-		add_child_node(sub_tree_root, right_child);
+		/**
+		 * If we are multiplying *and* the type is commutative, we will 
+		 * perform reordering here if need be
+		 */
+		if(is_type_commutative_for_operation(final_type, lookahead.tok) == TRUE
+			&& temp_holder->ast_node_type == AST_NODE_TYPE_CONSTANT){
+			//We'll now swap these two nodes so that the constant is on the right
+			add_child_node(sub_tree_root, right_child);
+			add_child_node(sub_tree_root, temp_holder);
+
+		/**
+		 * Otherwise all is normal so the temp holder goes on the left,
+		 * right child on the right
+		 */
+		} else {
+			add_child_node(sub_tree_root, temp_holder);
+			add_child_node(sub_tree_root, right_child);
+		}
 
 		//Store the final type
 		sub_tree_root->inferred_type = final_type;
@@ -5751,9 +5758,24 @@ static generic_ast_node_t* inclusive_or_expression(ollie_token_stream_t* token_s
 		//We'll now assign the binary expression it's operator
 		sub_tree_root->binary_operator = lookahead.tok;
 
-		//Now we add the 2 children in order
-		add_child_node(sub_tree_root, temp_holder);
-		add_child_node(sub_tree_root, right_child);
+		/**
+		 * If we are multiplying *and* the type is commutative, we will 
+		 * perform reordering here if need be
+		 */
+		if(is_type_commutative_for_operation(final_type, lookahead.tok) == TRUE
+			&& temp_holder->ast_node_type == AST_NODE_TYPE_CONSTANT){
+			//We'll now swap these two nodes so that the constant is on the right
+			add_child_node(sub_tree_root, right_child);
+			add_child_node(sub_tree_root, temp_holder);
+
+		/**
+		 * Otherwise all is normal so the temp holder goes on the left,
+		 * right child on the right
+		 */
+		} else {
+			add_child_node(sub_tree_root, temp_holder);
+			add_child_node(sub_tree_root, right_child);
+		}
 
 		//Store the final type
 		sub_tree_root->inferred_type = final_type;

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -230,6 +230,25 @@ static inline u_int8_t is_type_commutative_for_operation(generic_type_t* type, o
 
 			return TRUE;
 
+		/**
+		 * Equality operations are always going to be commutative
+		 */
+		case DOUBLE_EQUALS:
+		case NOT_EQUALS:
+			return TRUE;
+
+		/**
+		 * Bitwise and, or and xor are commutative
+		 */
+		case SINGLE_OR:
+		case SINGLE_AND:
+		case CARROT:
+			if(IS_FLOATING_POINT(type) == TRUE){
+				return FALSE;
+			}
+
+			return TRUE;
+			
 
 		//By defualt - we're assuming this operator is not commutative
 		default:
@@ -5303,10 +5322,24 @@ static generic_ast_node_t* equality_expression(ollie_token_stream_t* token_strea
 		//We'll now assign the binary expression it's operator
 		sub_tree_root->binary_operator = lookahead.tok;
 
-		//Add both child nodes in order only now that we know everything is valid
-		add_child_node(sub_tree_root, temp_holder);
-		//Otherwise, he is the right child of the sub_tree_root, so we'll add it in
-		add_child_node(sub_tree_root, right_child);
+		/**
+		 * If we are multiplying *and* the type is commutative, we will 
+		 * perform reordering here if need be
+		 */
+		if(is_type_commutative_for_operation(return_type, op.tok) == TRUE
+			&& temp_holder->ast_node_type == AST_NODE_TYPE_CONSTANT){
+			//We'll now swap these two nodes so that the constant is on the right
+			add_child_node(sub_tree_root, right_child);
+			add_child_node(sub_tree_root, temp_holder);
+
+		/**
+		 * Otherwise all is normal so the temp holder goes on the left,
+		 * right child on the right
+		 */
+		} else {
+			add_child_node(sub_tree_root, temp_holder);
+			add_child_node(sub_tree_root, right_child);
+		}
 
 		//Store the return type
 		sub_tree_root->inferred_type = return_type;
@@ -5436,9 +5469,24 @@ static generic_ast_node_t* and_expression(ollie_token_stream_t* token_stream, si
 		sub_tree_root = ast_node_alloc(AST_NODE_TYPE_BINARY_EXPR, side);
 		sub_tree_root->binary_operator = lookahead.tok;
 
-		//Add the child nodes in the proper order here
-		add_child_node(sub_tree_root, temp_holder);
-		add_child_node(sub_tree_root, right_child);
+		/**
+		 * If we are multiplying *and* the type is commutative, we will 
+		 * perform reordering here if need be
+		 */
+		if(is_type_commutative_for_operation(final_type, lookahead.tok) == TRUE
+			&& temp_holder->ast_node_type == AST_NODE_TYPE_CONSTANT){
+			//We'll now swap these two nodes so that the constant is on the right
+			add_child_node(sub_tree_root, right_child);
+			add_child_node(sub_tree_root, temp_holder);
+
+		/**
+		 * Otherwise all is normal so the temp holder goes on the left,
+		 * right child on the right
+		 */
+		} else {
+			add_child_node(sub_tree_root, temp_holder);
+			add_child_node(sub_tree_root, right_child);
+		}
 
 		//We now know that the subtree root has a type of u_int8(boolean)
 		sub_tree_root->inferred_type = final_type;

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -220,6 +220,16 @@ static inline u_int8_t is_type_commutative_for_operation(generic_type_t* type, o
 
 			return TRUE;
 
+		/**
+		 * For addition, any type that is *not* a float is commutative
+		 */
+		case PLUS:
+			if(IS_FLOATING_POINT(type) == TRUE){
+				return FALSE;
+			}
+
+			return TRUE;
+
 
 		//By defualt - we're assuming this operator is not commutative
 		default:
@@ -4798,18 +4808,32 @@ static generic_ast_node_t* additive_expression(ollie_token_stream_t* token_strea
 		//We'll now assign the binary expression it's operator
 		sub_tree_root->binary_operator = op.tok;
 
-		//We actually already know this guy's first child--it's the previous root currently
-		//being held in temp_holder. We'll add the temp holder in as the subtree root
-		add_child_node(sub_tree_root, temp_holder);
+		/**
+		 * If we are multiplying *and* the type is commutative, we will 
+		 * perform reordering here if need be
+		 */
+		if(is_type_commutative_for_operation(return_type, op.tok) == TRUE
+			&& temp_holder->ast_node_type == AST_NODE_TYPE_CONSTANT){
+			//We'll now swap these two nodes so that the constant is on the right
+			add_child_node(sub_tree_root, right_child);
+			add_child_node(sub_tree_root, temp_holder);
 
-		//Otherwise, he is the right child of the sub_tree_root, so we'll add it in
-		add_child_node(sub_tree_root, right_child);
+		/**
+		 * Otherwise all is normal so the temp holder goes on the left,
+		 * right child on the right
+		 */
+		} else {
+			add_child_node(sub_tree_root, temp_holder);
+			add_child_node(sub_tree_root, right_child);
+		}
 		
 		//Now we can finally assign the sub tree type
 		sub_tree_root->inferred_type = return_type;
 
-		//Copy over the variable. It will either be NULL(common case) or it will carry
-		//the value of the pointer that we manipulated
+		/**
+		 * Copy over the variable. It will either be NULL(common case) or it will carry
+		 * the value of the pointer that we manipulated
+		 */
 		sub_tree_root->variable = variable;
 
 		//By the end of this, we always have a proper subtree with the operator as the root, being held in 

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -205,6 +205,21 @@ static inline u_int8_t is_copy_assignment_required(generic_type_t* destination_t
 
 
 /**
+ * Is the given type commutative when the normal rules of
+ * arithmetic apply? 
+ */
+static inline u_int8_t is_type_commutative_for_operation(generic_type_t* type, ollie_token_t op){
+	switch(op){
+
+
+		//By defualt - we're assuming this operator is not commutative
+		default:
+			return FALSE;
+	}
+}
+
+
+/**
  * Perform any needed constant coercion that is being done for an assignment. This includes converting pointers to 64-bit
  * integers for constant coercion
  */
@@ -4365,6 +4380,11 @@ static generic_ast_node_t* cast_expression(ollie_token_stream_t* token_stream, s
  * will return a pointer to the root of the subtree that is created by it, whether that subtree
  * originated here or not
  *
+ * NOTE: multiplication is commutative for certain types, so we are able to dynamically reorder these
+ * if we have a multiplication instruction *and* we end up with a constant in the left hand child
+ *
+ * Example: 3 * x -> x * 3
+ *
  * BNF Rule: <multiplicative-expression> ::= <cast-expression>{ (* | / | %) <cast-expression>}*
  */
 static generic_ast_node_t* multiplicative_expression(ollie_token_stream_t* token_stream, side_type_t side){
@@ -4545,6 +4565,15 @@ static generic_ast_node_t* multiplicative_expression(ollie_token_stream_t* token
 
 		//We now need to make an operator node
 		sub_tree_root = ast_node_alloc(AST_NODE_TYPE_BINARY_EXPR, side);
+		
+		/**
+		 * If we are multiplying *and* the type is commutative, we will 
+		 * perform reordering here if need be
+		 */
+		if(op.tok == STAR) {
+
+		}
+
 
 		//We'll now assign the binary expression it's operator
 		sub_tree_root->binary_operator = lookahead.tok;
@@ -4583,6 +4612,8 @@ static generic_ast_node_t* multiplicative_expression(ollie_token_stream_t* token
  *  4.) Unsigned will always dominate signed
  *
  * BNF Rule: <additive-expression> ::= <multiplicative-expression>{ (+ | -) <multiplicative-expression>}*
+ *
+ * TODO HERE
  */
 static generic_ast_node_t* additive_expression(ollie_token_stream_t* token_stream, side_type_t side){
 	//Lookahead token
@@ -5112,6 +5143,8 @@ static generic_ast_node_t* relational_expression(ollie_token_stream_t* token_str
  * always return a pointer to the subtree, whether that subtree is made here or elsewhere
  *
  * BNF Rule: <equality-expression> ::= <relational-expression>{ (==|!=) <relational-expression> }*
+ *
+ * TODO HERE
  */
 static generic_ast_node_t* equality_expression(ollie_token_stream_t* token_stream, side_type_t side){
 	//Lookahead token
@@ -5259,6 +5292,8 @@ static generic_ast_node_t* equality_expression(ollie_token_stream_t* token_strea
  * at a rule lower down on the tree
  *
  * BNF Rule: <and-expression> ::= <equality-expression>{& <equality-expression>}* 
+ *
+ * TODO HERE
  */
 static generic_ast_node_t* and_expression(ollie_token_stream_t* token_stream, side_type_t side){
 	//Lookahead token
@@ -5389,6 +5424,8 @@ static generic_ast_node_t* and_expression(ollie_token_stream_t* token_stream, si
  * the chain
  *
  * BNF Rule: <exclusive-or-expression> ::= <and-expression>{^ <and-expression}*
+ *
+ * TODO HERE
  */
 static generic_ast_node_t* exclusive_or_expression(ollie_token_stream_t* token_stream, side_type_t side){
 	//Lookahead token
@@ -5517,6 +5554,8 @@ static generic_ast_node_t* exclusive_or_expression(ollie_token_stream_t* token_s
 /**
  * An inclusive or expression will always return a reference to the root node of it's subtree. That node
  * could be an operator or it could be a passthrough
+ *
+ * NOTE: inclusive or is a commutative type, so it is eligible for constant reordering
  *
  * BNF rule: <inclusive-or-expression> ::= <exclusive-or-expression>{ | <exclusive-or-expression>}*
  */

--- a/oc/test_files/reorder_bitwise.ol
+++ b/oc/test_files/reorder_bitwise.ol
@@ -1,0 +1,23 @@
+/**
+* Author: Jack Robbins
+* Test the parser's ability to automatically reorder bitwise instructions
+*/
+
+pub fn reorder_xor(x:i32) -> i32 {
+	ret 4 ^ x;
+}
+
+
+pub fn reorder_or(x:i32) -> i32 {
+	ret 4 | x;
+}
+
+
+pub fn reorder_and(x:i32) -> i32 {
+	ret 4 & x;
+}
+
+
+pub fn main() -> i32 {
+	ret 0;
+}

--- a/oc/test_files/reordering_test.ol
+++ b/oc/test_files/reordering_test.ol
@@ -1,0 +1,16 @@
+/**
+* Author: Jack Robbins
+* Test some basic reordering of eligible expressions with constants
+*/
+
+
+pub fn main() -> i32 {
+	let x:i32 = 5;
+
+	/**
+	* We should recognize the opportunity here and reorder
+	* this into x * 4 + 5. They will both give the right
+	* result of 25
+	*/
+	ret 5 + 4 * x;
+}


### PR DESCRIPTION
[Parser]: parser can now recognize and reoreder eligible expressions to guarantee that the constant is in the right hand side always

Closes #824 