### PR TITLE
[Full Stack]- Efficiency Improvement: all heap_queues have been made reusable

### DIFF
--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -68,6 +68,10 @@ static dynamic_array_t current_function_labeled_blocks;
 static dynamic_array_t current_function_user_defined_jump_statements;
 //The current stack offset for any given function
 static u_int64_t stack_offset = 0;
+
+//Reusable memory regions for our graph traversals
+static heap_queue_t traversal_queue;
+
 //For any/all error printing
 char error_info[1500];
 
@@ -1443,13 +1447,12 @@ static basic_block_t* immediate_dominator(basic_block_t* B){
  */
 static basic_block_t* immediate_postdominator(basic_block_t* B){
 	//If we've already found the immediate dominator, why find it again?
-	//We'll just give that back
 	if(B->immediate_postdominator != NULL){
 		return B->immediate_postdominator;
 	}
 
-	//Create the queue
-	heap_queue_t queue = heap_queue_alloc();
+	//First we'll wipe the queue clean
+	heap_queue_clear(&traversal_queue);
 
 	//The visited array
 	dynamic_array_t visited = dynamic_array_alloc();
@@ -1461,12 +1464,12 @@ static basic_block_t* immediate_postdominator(basic_block_t* B){
 	dynamic_array_t postdominator_set = B->postdominator_set;
 
 	//Seed the search with B
-	enqueue(&queue, B);
+	enqueue(&traversal_queue, B);
 
 	//So long as the queue isn't empty
-	while(queue_is_empty(&queue) == FALSE){
+	while(queue_is_empty(&traversal_queue) == FALSE){
 		//Pop off of the queue
-		basic_block_t* current = dequeue(&queue);
+		basic_block_t* current = dequeue(&traversal_queue);
 
 		/**
 		 * If we have found the first breadth-first successor that postdominates B,
@@ -1486,16 +1489,13 @@ static basic_block_t* immediate_postdominator(basic_block_t* B){
 			basic_block_t* successor = current->successors.internal_array[j];
 
 			if(dynamic_array_contains(&visited, successor) == NOT_FOUND){
-				enqueue(&queue, successor);
+				enqueue(&traversal_queue, successor);
 			}
 		}
 	}
 
 	//Destroy visited
 	dynamic_array_dealloc(&visited);
-
-	//Destroy the queue
-	heap_queue_dealloc(&queue);
 
 	//Give it back
 	return ipdom;
@@ -11133,6 +11133,7 @@ cfg_t* build_cfg(front_end_results_package_t* results, u_int32_t* num_errors, u_
 	break_stack = heap_stack_alloc();
 	continue_stack = heap_stack_alloc(); 
 	nesting_stack = nesting_stack_alloc();
+	traversal_queue = heap_queue_alloc();
 
 	//Keep these on hand
 	f64 = lookup_type_name_only(type_symtab, "f64", NOT_MUTABLE)->type;

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -6840,9 +6840,9 @@ static void emit_blocks_bfs(cfg_t* cfg, emit_dominance_frontier_selection_t prin
 
 	//Now we'll print out each and every function inside of the function_entry_blocks
 	//array. Each function will be printed using the BFS strategy
-	for(u_int16_t i = 0; i < cfg->function_entry_blocks.current_index; i++){
-		//We'll need a queue for our BFS
-		heap_queue_t queue = heap_queue_alloc();
+	for(u_int32_t i = 0; i < cfg->function_entry_blocks.current_index; i++){
+		//Clear the traversal queue
+		heap_queue_clear(&traversal_queue);
 
 		//Grab this out for convenience
 		basic_block_t* function_entry_block = dynamic_array_get_at(&(cfg->function_entry_blocks), i);
@@ -6852,12 +6852,12 @@ static void emit_blocks_bfs(cfg_t* cfg, emit_dominance_frontier_selection_t prin
 		print_local_stack_data_area(&(function_entry_block->function_defined_in->local_stack));
 
 		//Seed the search by adding the funciton block into the queue
-		enqueue(&queue, function_entry_block);
+		enqueue(&traversal_queue, function_entry_block);
 
 		//So long as the queue isn't empty
-		while(queue_is_empty(&queue) == FALSE){
+		while(queue_is_empty(&traversal_queue) == FALSE){
 			//Pop off of the queue
-			block = dequeue(&queue);
+			block = dequeue(&traversal_queue);
 
 			//If this wasn't visited, we'll print
 			if(block->visited == FALSE){
@@ -6873,13 +6873,10 @@ static void emit_blocks_bfs(cfg_t* cfg, emit_dominance_frontier_selection_t prin
 				basic_block_t* successor = block->successors.internal_array[j];
 
 				if(successor->visited == FALSE){
-					enqueue(&queue, successor);
+					enqueue(&traversal_queue, successor);
 				}
 			}
 		}
-
-		//Destroy the heap queue when done
-		heap_queue_dealloc(&queue);
 	}
 }
 

--- a/oc/compiler/optimizer/optimizer.c
+++ b/oc/compiler/optimizer/optimizer.c
@@ -16,6 +16,9 @@
 static three_addr_var_t* stack_pointer_variable;
 static three_addr_var_t* instruction_pointer_variable;
 
+//A reusable queue for postdominator traversal
+static heap_queue_t postdominator_queue;
+
 //A pointer to the cfg
 static cfg_t* cfg_reference;
 
@@ -866,23 +869,23 @@ static void replace_all_branch_targets(basic_block_t* empty_block, basic_block_t
  * we'll have our answer
  */
 static basic_block_t* nearest_marked_postdominator(dynamic_array_t* function_blocks, basic_block_t* B){
-	//We'll need a queue for the BFS
-	heap_queue_t queue = heap_queue_alloc();
+	//Wipe out the postdominator queue for this go around
+	heap_queue_clear(&postdominator_queue);
 
 	//First, we'll reset every single block here
 	reset_visit_status_for_function(function_blocks);
 
 	//Seed the search with B
-	enqueue(&queue, B);
+	enqueue(&postdominator_queue, B);
 
 	//The nearest marked postdominator and a holder for our candidates
 	basic_block_t* nearest_marked_postdominator = NULL;
 	basic_block_t* candidate;
 
 	//So long as the queue is not empty
-	while(queue_is_empty(&queue) == FALSE){
+	while(queue_is_empty(&postdominator_queue) == FALSE){
 		//Grab the block off
-		candidate = dequeue(&queue);
+		candidate = dequeue(&postdominator_queue);
 		
 		//If we've been here before, continue;
 		if(candidate->visited == TRUE){
@@ -914,13 +917,10 @@ static basic_block_t* nearest_marked_postdominator(dynamic_array_t* function_blo
 
 			//If it's already been visited, we won't bother with it. If it hasn't been visited, we'll add it in
 			if(successor->visited == FALSE){
-				enqueue(&queue, successor);
+				enqueue(&postdominator_queue, successor);
 			}
 		}
 	}
-
-	//Destroy the queue when done
-	heap_queue_dealloc(&queue);
 
 	//And give this back
 	return nearest_marked_postdominator;
@@ -3127,6 +3127,9 @@ cfg_t* optimize(cfg_t* cfg){
 	stack_pointer_variable = cfg->stack_pointer;
 	instruction_pointer_variable = cfg->instruction_pointer;
 
+	//Allocate the reusable memory
+	postdominator_queue = heap_queue_alloc();
+
 	/**
 	 * We will optimize on a function by function basis. This is because functions are independent units 
 	 * that do not have interlocking dependencies. Us doing this allows for more efficient operation because
@@ -3251,6 +3254,8 @@ cfg_t* optimize(cfg_t* cfg){
 		recompute_all_dominance_relations(current_function_blocks, function_entry_block);
 	}
 
+	//Now that we are done we can free all of the reusable memory
+	heap_queue_dealloc(&postdominator_queue);
 
 	//Give back the CFG
 	return cfg;

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -41,6 +41,8 @@ static symtab_function_record_t* current_function = NULL;
 static dynamic_set_t errors_raised_by_current_function;
 //The queue that holds all of our jump statements for a given function
 static heap_queue_t current_function_jump_statements;
+//The BFS queue for namespaces
+static heap_queue_t namespace_bfs_queue;
 
 //Our stack for storing variables, etc
 static lex_stack_t grouping_stack;
@@ -1706,8 +1708,7 @@ static inline u_int8_t is_namespace_predecessor_of_given(function_namespace_t* p
 	 * and eventually find the current namespace, then the function is
 	 * inside of a predecessor namespace and this access is valid
 	 */
-	//We'll need a queue for the BFS
-	heap_queue_t namespace_bfs_queue = heap_queue_alloc();
+	heap_queue_clear(&namespace_bfs_queue);
 
 	//Add the function namespace as our seed
 	enqueue(&namespace_bfs_queue, predecessor_candidate);
@@ -1719,8 +1720,6 @@ static inline u_int8_t is_namespace_predecessor_of_given(function_namespace_t* p
 
 		//Condition - if it's equal to our current one get out
 		if(cursor == given){
-			//Destroy the queue
-			heap_queue_dealloc(&namespace_bfs_queue);
 			return SUCCESS;
 		}
 
@@ -1730,8 +1729,6 @@ static inline u_int8_t is_namespace_predecessor_of_given(function_namespace_t* p
 
 			//If this matches the  current namespace - we're done 
 			if(candidate == given){
-				//Destroy the queue
-				heap_queue_dealloc(&namespace_bfs_queue);
 				return SUCCESS;
 			}
 
@@ -1739,9 +1736,6 @@ static inline u_int8_t is_namespace_predecessor_of_given(function_namespace_t* p
 			enqueue(&namespace_bfs_queue, candidate);
 		}
 	}
-
-	//Scrap the queue
-	heap_queue_dealloc(&namespace_bfs_queue);
 
 	//If we made it all the way down here, we have a failure
 	return FAILURE;
@@ -14247,6 +14241,9 @@ front_end_results_package_t* parse(compiler_options_t* options){
 	variable_symtab = variable_symtab_alloc();
 	type_symtab = type_symtab_alloc();
 
+	//Allocate the reusable namespace queue
+	namespace_bfs_queue = heap_queue_alloc();
+
 	//For the type and variable symtabs, their scope needs to be initialized before
 	//anything else happens
 	
@@ -14345,6 +14342,7 @@ front_end_results_package_t* parse(compiler_options_t* options){
 	lex_stack_dealloc(&grouping_stack);
 	lex_stack_dealloc(&assignment_grouping_stack);
 	nesting_stack_dealloc(&nesting_stack);
+	heap_queue_dealloc(&namespace_bfs_queue);
 
 	//Once we're done, destroy the token stream
 	destroy_token_stream(token_stream);

--- a/oc/compiler/postprocessor/postprocessor.c
+++ b/oc/compiler/postprocessor/postprocessor.c
@@ -18,6 +18,9 @@
 static three_addr_var_t* stack_pointer_variable;
 static three_addr_var_t* instruction_pointer_variable;
 
+// A reusable queue for our traversals
+static heap_queue_t bfs_queue;
+
 /**
  * We only want to perform ret-hoisting for small enough
  * blocks. If we have gigantic ret blocks, hoisting them
@@ -822,23 +825,23 @@ static void condense(cfg_t* cfg, basic_block_t* function_entry_block){
 static void reorder_blocks(basic_block_t* function_entry_block){
 	//We'll first wipe the visited status on this CFG
 	reset_function_visited_status(function_entry_block, TRUE);
+
+	//Clear out our reusable queue
+	heap_queue_clear(&bfs_queue);
 	
 	//We will perform a breadth first search and use the "direct successor" area
 	//of the blocks to store them all in one chain
 	
-	//We'll need to use a queue every time, we may as well just have one big one
-	heap_queue_t queue = heap_queue_alloc();
-
 	//These are reset for every function we deal with
 	basic_block_t* previous = NULL;
 
 	//This function start block is the begging of our BFS	
-	enqueue(&queue, function_entry_block);
+	enqueue(&bfs_queue, function_entry_block);
 	
 	//So long as the queue is not empty
-	while(queue_is_empty(&queue) == FALSE){
+	while(queue_is_empty(&bfs_queue) == FALSE){
 		//Grab this block off of the queue
-		basic_block_t* current = dequeue(&queue);
+		basic_block_t* current = dequeue(&bfs_queue);
 
 		//If previous is NULL, this is the first block
 		if(previous == NULL){
@@ -876,7 +879,7 @@ static void reorder_blocks(basic_block_t* function_entry_block){
 		//If this is the case, we'll add it in first
 		if(direct_end_jump != NULL && direct_end_jump->visited == FALSE){
 			//Add it into the queue
-			enqueue(&queue, direct_end_jump);
+			enqueue(&bfs_queue, direct_end_jump);
 		}
 
 		//Now we'll go through each of the successors in this node
@@ -900,13 +903,10 @@ static void reorder_blocks(basic_block_t* function_entry_block){
 
 			//Otherwise it's not, so we'll add it in
 			if(successor->visited == FALSE){
-				enqueue(&queue, successor);
+				enqueue(&bfs_queue, successor);
 			}
 		}
 	}
-
-	//Destroy the queue when done
-	heap_queue_dealloc(&queue);
 }
 
 
@@ -922,6 +922,9 @@ void postprocess(cfg_t* cfg){
 	//Cache these two special variables
 	stack_pointer_variable = cfg->stack_pointer;
 	instruction_pointer_variable = cfg->instruction_pointer;
+
+	//Allocate the reusable queue
+	bfs_queue = heap_queue_alloc();
 
 	//Run through every function block here separately
 	for(u_int32_t i = 0 ; i < cfg->function_entry_blocks.current_index; i++){
@@ -943,4 +946,7 @@ void postprocess(cfg_t* cfg){
 		*/
 		reorder_blocks(function_entry_block);
 	}
+
+	//We can now destroy the output queue
+	heap_queue_dealloc(&bfs_queue);
 }


### PR DESCRIPTION
[Full Stack]- Efficiency Improvement: all heap_queues have been made reusable. This will cut down on memory allocations occurring with every time a new queue is needed for a BFS traversal, some other traversal, etc.

Closes #836 
Closes #837 