### PR TITLE
[TRIAGED FIX]: MulX instructions now correctly represent the clobbered %rdx register

### DIFF
--- a/oc/compiler/instruction/instruction.c
+++ b/oc/compiler/instruction/instruction.c
@@ -3636,6 +3636,8 @@ static void print_unsigned_multiplication_instruction(FILE* fl, instruction_t* i
 	//Print where this went
 	fprintf(fl, " -->  ");
 	//Print this mode
+	print_variable(fl, instruction->destination_register2, mode);
+	fprintf(fl, ":");
 	print_variable(fl, instruction->destination_register, mode);
 
 	fprintf(fl, " */\n");

--- a/oc/compiler/instruction_selector/instruction_selector.c
+++ b/oc/compiler/instruction_selector/instruction_selector.c
@@ -8116,7 +8116,7 @@ static inline instruction_type_t select_unsigned_mulitplication_instruction(vari
  *
  * NOTE: this is always the first instruction in the instruction window
  *
- * An important note - since we use the one operand signed multiplication instruction, we
+ * An important note - since we use the one operand unsigned multiplication instruction, we
  * clobber the %rdx register whenever we do this. Even though we do not use it, this is 
  * something that we need to account for
 */
@@ -8195,7 +8195,11 @@ static void handle_unsigned_multiplication_instruction(instruction_window_t* win
 
 	//This is the assignee, we just don't see it
 	multiplication_instruction->destination_register = emit_temp_var(destination_type);
-	//For our clobbering
+
+	/**
+	 * Populate the second destination register for clobbering. This will be updated
+	 * to be %rdx by the precolorer by the time we reach the register allocator
+	 */
 	multiplication_instruction->destination_register2 = emit_temp_var(destination_type);
 
 	//Once we've done all that, we need one final movement operation

--- a/oc/compiler/instruction_selector/instruction_selector.c
+++ b/oc/compiler/instruction_selector/instruction_selector.c
@@ -8115,6 +8115,10 @@ static inline instruction_type_t select_unsigned_mulitplication_instruction(vari
  * mull %rcx -> result in rax
  *
  * NOTE: this is always the first instruction in the instruction window
+ *
+ * An important note - since we use the one operand signed multiplication instruction, we
+ * clobber the %rdx register whenever we do this. Even though we do not use it, this is 
+ * something that we need to account for
 */
 static void handle_unsigned_multiplication_instruction(instruction_window_t* window){
 	//Instruction 1 is the multiplication instruction
@@ -8191,6 +8195,8 @@ static void handle_unsigned_multiplication_instruction(instruction_window_t* win
 
 	//This is the assignee, we just don't see it
 	multiplication_instruction->destination_register = emit_temp_var(destination_type);
+	//For our clobbering
+	multiplication_instruction->destination_register2 = emit_temp_var(destination_type);
 
 	//Once we've done all that, we need one final movement operation
 	instruction_t* result_movement = emit_move_instruction(multiplication_instruction->assignee, multiplication_instruction->destination_register);

--- a/oc/compiler/register_allocator/register_allocator.c
+++ b/oc/compiler/register_allocator/register_allocator.c
@@ -2096,6 +2096,9 @@ static void precolor_instruction(instruction_t* instruction){
 			//The destination must also be in RAX here
 			instruction->destination_register->associated_live_range->reg.gen_purpose = RAX;
 
+			//The implicit higher order bit destination is always RDX
+			instruction->destination_register2->associated_live_range->reg.gen_purpose = RDX;
+
 			break;
 
 		/**


### PR DESCRIPTION
[TRIAGED FIX]: MulX instructions now correctly represent the clobbered %rdx register

Closes #877 