### PR TITLE
[CFG]: add support for array, pointer types inside of elaborative parameters

### DIFF
--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -4805,6 +4805,12 @@ static cfg_result_package_t emit_array_offset_calculation(basic_block_t* block, 
 				//TODO WE NEED TO DO SOMETHING FOR ELABORATIVE PARAMS - these aren't
 				//arrays they are always pointers, but the multiplier is treating
 				//them as full array sizes
+				/**
+				 * If we have an elaborative param type, we 
+				 */
+//				if((*base_address)->type->type_class == TYPE_CLASS_ELABORATIVE){
+//					printf("ELABORATIVE\n");
+//				}
 
 				/**
 				 * The formula for array subscript is: base_address + type_size * subscript
@@ -7748,6 +7754,8 @@ static inline void handle_elaborative_stack_param_storage(basic_block_t* basic_b
 					/**
 					 * Array types are always passed along by pointer. We will be using the generic pointer
 					 * type to do this(void*)
+					 *
+					 * TODO WE SHOULD UPDATE THIS TO BE A POINTER TYPE THAT'S AN ACTUAL REPRESENTATION
 					 */
 					case TYPE_CLASS_ARRAY:
 						//Create this one's stack region

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -5297,8 +5297,6 @@ static cfg_result_package_t emit_postfix_expression_rec(basic_block_t* basic_blo
 				//Emit a special instruction for IR clarity
 				instruction_t* elaborative_param_offset = emit_elaborative_param_starting_offset_calculation(new_current_offset, emit_var(base_address_variable));
 
-				//TODO DO WE NEED AUTOMATIC DEREF???
-
 				//Put it into the block
 				add_statement(current, elaborative_param_offset);
 
@@ -5343,8 +5341,6 @@ static cfg_result_package_t emit_postfix_expression_rec(basic_block_t* basic_blo
 	//The type of the memory region we're accessing is all we need here. This is always
 	//the left child's type
 	generic_type_t* memory_region_type = left_child->inferred_type;
-
-	printf("MEMORY REGION TYPE IS %s\n", memory_region_type->type_name.string);
 
 	//We need to first recursively emit the left child's postfix expression
 	cfg_result_package_t left_child_results = emit_postfix_expression_rec(basic_block, left_child, base_address, current_offset, came_from_non_contiguous_region);

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -4802,16 +4802,6 @@ static cfg_result_package_t emit_array_offset_calculation(basic_block_t* block, 
 				//This is whatever was emitted by the expression
 				three_addr_var_t* array_offset = expression_package.result_value.result_var;
 
-				//TODO WE NEED TO DO SOMETHING FOR ELABORATIVE PARAMS - these aren't
-				//arrays they are always pointers, but the multiplier is treating
-				//them as full array sizes
-				/**
-				 * If we have an elaborative param type, we 
-				 */
-//				if((*base_address)->type->type_class == TYPE_CLASS_ELABORATIVE){
-//					printf("ELABORATIVE\n");
-//				}
-
 				/**
 				 * The formula for array subscript is: base_address + type_size * subscript
 				 * 

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -7744,6 +7744,8 @@ static inline void handle_elaborative_stack_param_storage(basic_block_t* basic_b
 					 * type to do this(void*)
 					 */
 					case TYPE_CLASS_ARRAY:
+						printf("HERE\n\n\n");
+
 						//Create this one's stack region
 						variable_result_region = create_stack_region_for_type(stack_passed_parameters, immut_void_ptr);
 
@@ -7751,7 +7753,7 @@ static inline void handle_elaborative_stack_param_storage(basic_block_t* basic_b
 						var_storage_offset = emit_direct_integer_or_char_constant(variable_result_region->function_local_base_address, u64);
 
 						//Now emit the store instruction for the result
-						var_elaborative_param_store = emit_store_with_constant_offset_ir_code(stack_pointer_variable, var_storage_offset, result_var, result_var->type); 
+						var_elaborative_param_store = emit_store_with_constant_offset_ir_code(stack_pointer_variable, var_storage_offset, result_var, immut_void_ptr); 
 
 						//Add it into the block
 						add_statement(basic_block, var_elaborative_param_store);

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -3054,26 +3054,28 @@ static three_addr_var_t* handle_pointer_arithmetic(basic_block_t* basic_block, o
  * Emit the appropriate address calculation for a given array member, based on what is given in the parameters. This will
  * result in either a lea or a binary operation and then a lea
  */
-static three_addr_var_t* emit_array_address_calculation(basic_block_t* basic_block, three_addr_var_t* base_addr, three_addr_var_t* offset, generic_type_t* member_type){
+static three_addr_var_t* emit_array_address_calculation(basic_block_t* basic_block, three_addr_var_t* base_addr, three_addr_var_t* offset, u_int64_t type_size){
 	//We need a new temp var for the assignee. We know it's an address always
 	three_addr_var_t* assignee = emit_temp_var(i64);
 
 	//Is this a lea compatible power of 2? If so we will use the lea shortcut
-	if(is_lea_compatible_power_of_2(member_type->type_size) == TRUE){
+	if(is_lea_compatible_power_of_2(type_size) == TRUE){
 		//Let the helper emit the lea
-		instruction_t* address_calculation = emit_lea_multiplier_and_operands(assignee, base_addr, offset, member_type->type_size);
+		instruction_t* address_calculation = emit_lea_multiplier_and_operands(assignee, base_addr, offset, type_size);
 
 		//Get this into the block
 		add_statement(basic_block, address_calculation);
 
-	//Otherwise, we can't fully do a lea here so we'll need to instead
-	//use a binary operation to multiply followed by a different kind of lea
+	/**
+	 * Otherwise, we can't fully do a lea here so we'll need to instead
+	 * use a binary operation to multiply followed by a different kind of lea
+	 */
 	} else {
 		//We'll need the size to multiply by
-		three_addr_const_t* type_size = emit_direct_integer_or_char_constant(member_type->type_size, u64);
+		three_addr_const_t* type_size_const = emit_direct_integer_or_char_constant(type_size, u64);
 
 		//Let the helper emit the entire thing. We'll store into a temp var there
-		three_addr_var_t* final_offset = emit_binary_operation_with_constant(basic_block, emit_temp_var(u64), offset, STAR, type_size);
+		three_addr_var_t* final_offset = emit_binary_operation_with_constant(basic_block, emit_temp_var(u64), offset, STAR, type_size_const);
 
 		//And now that we have the incompatible multiplication over with, we can use a lea to add
 		instruction_t* lea_statement = emit_lea_operands_only(assignee, base_addr, final_offset);
@@ -4811,7 +4813,7 @@ static cfg_result_package_t emit_array_offset_calculation(basic_block_t* block, 
 				 *
 				 * This can be done using a lea instruction, so we will emit that directly
 				 */
-				three_addr_var_t* address = emit_array_address_calculation(current_block, *current_offset, array_offset, member_type);
+				three_addr_var_t* address = emit_array_address_calculation(current_block, *current_offset, array_offset, member_type->type_size);
 
 				//And finally - our current offset is no longer the actual offset
 				*current_offset = address;

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -7681,6 +7681,7 @@ static inline void handle_elaborative_stack_param_storage(basic_block_t* basic_b
 		three_addr_const_t* result_const;
 		stack_region_t* variable_result_region;
 		three_addr_const_t* var_storage_offset;
+		instruction_t* var_elaborative_param_store;
 
 		/**
 		 * Based on what kind of result that we have, we will handle
@@ -7739,6 +7740,25 @@ static inline void handle_elaborative_stack_param_storage(basic_block_t* basic_b
 						break;
 
 					/**
+					 * Array types are always passed along by pointer. We will be using the generic pointer
+					 * type to do this(void*)
+					 */
+					case TYPE_CLASS_ARRAY:
+						//Create this one's stack region
+						variable_result_region = create_stack_region_for_type(stack_passed_parameters, immut_void_ptr);
+
+						//Emit the storage offset for this value
+						var_storage_offset = emit_direct_integer_or_char_constant(variable_result_region->function_local_base_address, u64);
+
+						//Now emit the store instruction for the result
+						var_elaborative_param_store = emit_store_with_constant_offset_ir_code(stack_pointer_variable, var_storage_offset, result_var, result_var->type); 
+
+						//Add it into the block
+						add_statement(basic_block, var_elaborative_param_store);
+							
+						break;
+
+					/**
 					 * Everything else we perform a normal store. There is no copy assignment required to make this happen
 					 */
 					default:
@@ -7749,7 +7769,7 @@ static inline void handle_elaborative_stack_param_storage(basic_block_t* basic_b
 						var_storage_offset = emit_direct_integer_or_char_constant(variable_result_region->function_local_base_address, u64);
 
 						//Now emit the store instruction for the result
-						instruction_t* var_elaborative_param_store = emit_store_with_constant_offset_ir_code(stack_pointer_variable, var_storage_offset, result_var, result_var->type); 
+						var_elaborative_param_store = emit_store_with_constant_offset_ir_code(stack_pointer_variable, var_storage_offset, result_var, result_var->type); 
 
 						//Add it into the block
 						add_statement(basic_block, var_elaborative_param_store);

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -7744,8 +7744,6 @@ static inline void handle_elaborative_stack_param_storage(basic_block_t* basic_b
 					 * type to do this(void*)
 					 */
 					case TYPE_CLASS_ARRAY:
-						printf("HERE\n\n\n");
-
 						//Create this one's stack region
 						variable_result_region = create_stack_region_for_type(stack_passed_parameters, immut_void_ptr);
 

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -4800,6 +4800,10 @@ static cfg_result_package_t emit_array_offset_calculation(basic_block_t* block, 
 				//This is whatever was emitted by the expression
 				three_addr_var_t* array_offset = expression_package.result_value.result_var;
 
+				//TODO WE NEED TO DO SOMETHING FOR ELABORATIVE PARAMS - these aren't
+				//arrays they are always pointers, but the multiplier is treating
+				//them as full array sizes
+
 				/**
 				 * The formula for array subscript is: base_address + type_size * subscript
 				 * 

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -7754,12 +7754,10 @@ static inline void handle_elaborative_stack_param_storage(basic_block_t* basic_b
 					/**
 					 * Array types are always passed along by pointer. We will be using the generic pointer
 					 * type to do this(void*)
-					 *
-					 * TODO WE SHOULD UPDATE THIS TO BE A POINTER TYPE THAT'S AN ACTUAL REPRESENTATION
 					 */
 					case TYPE_CLASS_ARRAY:
 						//Create this one's stack region
-						variable_result_region = create_stack_region_for_type(stack_passed_parameters, immut_void_ptr);
+						variable_result_region = create_stack_region_for_type(stack_passed_parameters, convert_array_type_to_equivalent_pointer(result_var->type));
 
 						//Emit the storage offset for this value
 						var_storage_offset = emit_direct_integer_or_char_constant(variable_result_region->function_local_base_address, u64);

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -5297,6 +5297,8 @@ static cfg_result_package_t emit_postfix_expression_rec(basic_block_t* basic_blo
 				//Emit a special instruction for IR clarity
 				instruction_t* elaborative_param_offset = emit_elaborative_param_starting_offset_calculation(new_current_offset, emit_var(base_address_variable));
 
+				//TODO DO WE NEED AUTOMATIC DEREF???
+
 				//Put it into the block
 				add_statement(current, elaborative_param_offset);
 
@@ -5341,6 +5343,8 @@ static cfg_result_package_t emit_postfix_expression_rec(basic_block_t* basic_blo
 	//The type of the memory region we're accessing is all we need here. This is always
 	//the left child's type
 	generic_type_t* memory_region_type = left_child->inferred_type;
+
+	printf("MEMORY REGION TYPE IS %s\n", memory_region_type->type_name.string);
 
 	//We need to first recursively emit the left child's postfix expression
 	cfg_result_package_t left_child_results = emit_postfix_expression_rec(basic_block, left_child, base_address, current_offset, came_from_non_contiguous_region);

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -53,7 +53,7 @@ static generic_type_t* u64 = NULL;
 static generic_type_t* i64 = NULL;
 static generic_type_t* f32 = NULL;
 static generic_type_t* f64 = NULL;
-static generic_type_t* immut_void_ptr = NULL;
+
 /**
  * The break and continue stack will
  * hold values that we can break & continue
@@ -7530,7 +7530,7 @@ static inline void handle_parameter_storage(basic_block_t* basic_block, paramete
 						 * this and it will be fine
 						 */
 						if(parameter_type->type_class == TYPE_CLASS_ARRAY){
-							parameter_type = immut_void_ptr;
+							parameter_type = convert_array_type_to_equivalent_pointer(parameter_type);
 						}
 
 						//Create it
@@ -7600,7 +7600,7 @@ static inline void handle_parameter_storage(basic_block_t* basic_block, paramete
 						 * this and it will be fine
 						 */
 						if(parameter_type->type_class == TYPE_CLASS_ARRAY){
-							parameter_type = immut_void_ptr;
+							parameter_type = convert_array_type_to_equivalent_pointer(parameter_type);
 						}
 
 						//Create it
@@ -7684,6 +7684,7 @@ static inline void handle_elaborative_stack_param_storage(basic_block_t* basic_b
 		stack_region_t* variable_result_region;
 		three_addr_const_t* var_storage_offset;
 		instruction_t* var_elaborative_param_store;
+		generic_type_t* equivalent_pointer_type;
 
 		/**
 		 * Based on what kind of result that we have, we will handle
@@ -7742,18 +7743,21 @@ static inline void handle_elaborative_stack_param_storage(basic_block_t* basic_b
 						break;
 
 					/**
-					 * Array types are always passed along by pointer. We will be using the generic pointer
-					 * type to do this(void*)
+					 * Array types are always passed along by pointer. We will be converting from the array type to a pointer
+					 * to do this
 					 */
 					case TYPE_CLASS_ARRAY:
+						//Conver
+						equivalent_pointer_type = convert_array_type_to_equivalent_pointer(result_var->type);
+
 						//Create this one's stack region
-						variable_result_region = create_stack_region_for_type(stack_passed_parameters, convert_array_type_to_equivalent_pointer(result_var->type));
+						variable_result_region = create_stack_region_for_type(stack_passed_parameters, equivalent_pointer_type);
 
 						//Emit the storage offset for this value
 						var_storage_offset = emit_direct_integer_or_char_constant(variable_result_region->function_local_base_address, u64);
 
 						//Now emit the store instruction for the result
-						var_elaborative_param_store = emit_store_with_constant_offset_ir_code(stack_pointer_variable, var_storage_offset, result_var, immut_void_ptr); 
+						var_elaborative_param_store = emit_store_with_constant_offset_ir_code(stack_pointer_variable, var_storage_offset, result_var, equivalent_pointer_type);
 
 						//Add it into the block
 						add_statement(basic_block, var_elaborative_param_store);
@@ -12390,7 +12394,6 @@ cfg_t* build_cfg(front_end_results_package_t* results, u_int32_t* num_errors, u_
 	i16 = lookup_type_name_only(type_symtab, "i16", NOT_MUTABLE)->type;
 	u8 = lookup_type_name_only(type_symtab, "u8", NOT_MUTABLE)->type;
 	i8 = lookup_type_name_only(type_symtab, "i8", NOT_MUTABLE)->type;
-	immut_void_ptr = lookup_type_name_only(type_symtab, "void*", NOT_MUTABLE)->type;
 	char_type = lookup_type_name_only(type_symtab, "char", NOT_MUTABLE)->type;
 
 	//We'll first create the fresh CFG here

--- a/oc/compiler/instruction_selector/instruction_selector.c
+++ b/oc/compiler/instruction_selector/instruction_selector.c
@@ -2040,9 +2040,20 @@ static inline void optimize_mod_by_power_of_2(instruction_window_t* window){
  */
 static inline u_int64_t get_base_alignment_size_for_elaborative_param(generic_type_t* type_being_elaborated){
 	switch(type_being_elaborated->type_class){
+		/**
+		 * To enable aligned copying, all structs and unions for elaborative params are
+		 * aligned to 16 byte boundaries
+		 */
 		case TYPE_CLASS_STRUCT:
 		case TYPE_CLASS_UNION:
 			return 16;
+
+		/**
+		 * For arrays, we always pass by pointer so in reality we always
+		 * have 8 bytes to align by here
+		 */
+		case TYPE_CLASS_ARRAY:
+			return 8;
 
 		default:
 			return get_base_alignment_type(type_being_elaborated)->type_size;

--- a/oc/compiler/instruction_selector/instruction_selector.c
+++ b/oc/compiler/instruction_selector/instruction_selector.c
@@ -871,6 +871,8 @@ static void remediate_memory_address_variable_in_non_access_context(instruction_
 				/**
 				 * For our store operations, to rememdiate we just need to do everything that we would normally do 
 				 * before the store operation and replace the op1 with what we had
+				 *
+				 * TODO WRONG!!!!
 				 */
 				case THREE_ADDR_CODE_STORE_STATEMENT:
 				case THREE_ADDR_CODE_STORE_WITH_CONSTANT_OFFSET:
@@ -2035,10 +2037,23 @@ static u_int8_t simplify_window(instruction_window_t* window){
 		 * need to do remediations here as the regular store area cannot handle that
 		 */
 		case THREE_ADDR_CODE_STORE_STATEMENT:
-		case THREE_ADDR_CODE_STORE_WITH_CONSTANT_OFFSET:
-		case THREE_ADDR_CODE_STORE_WITH_VARIABLE_OFFSET:
 			if(first->op1 != NULL){
 				switch(first->op1->variable_type){
+					case VARIABLE_TYPE_MEMORY_ADDRESS:
+					case VARIABLE_TYPE_STACK_PARAM_MEMORY_ADDRESS:
+						remediate_memory_address_variable_in_non_access_context(window, first);
+						break;
+					default:
+						break;
+				}
+			}
+
+			break;
+
+		case THREE_ADDR_CODE_STORE_WITH_CONSTANT_OFFSET:
+		case THREE_ADDR_CODE_STORE_WITH_VARIABLE_OFFSET:
+			if(first->op2 != NULL){
+				switch(first->op2->variable_type){
 					case VARIABLE_TYPE_MEMORY_ADDRESS:
 					case VARIABLE_TYPE_STACK_PARAM_MEMORY_ADDRESS:
 						remediate_memory_address_variable_in_non_access_context(window, first);
@@ -2099,10 +2114,24 @@ static u_int8_t simplify_window(instruction_window_t* window){
 		 * need to do remediations here as the regular store area cannot handle that
 		 */
 		case THREE_ADDR_CODE_STORE_STATEMENT:
-		case THREE_ADDR_CODE_STORE_WITH_CONSTANT_OFFSET:
-		case THREE_ADDR_CODE_STORE_WITH_VARIABLE_OFFSET:
 			if(second->op1 != NULL){
 				switch(second->op1->variable_type){
+					case VARIABLE_TYPE_MEMORY_ADDRESS:
+					case VARIABLE_TYPE_STACK_PARAM_MEMORY_ADDRESS:
+						remediate_memory_address_variable_in_non_access_context(window, second);
+						break;
+
+					default:
+						break;
+				}
+			}
+			
+			break;
+
+		case THREE_ADDR_CODE_STORE_WITH_CONSTANT_OFFSET:
+		case THREE_ADDR_CODE_STORE_WITH_VARIABLE_OFFSET:
+			if(second->op2 != NULL){
+				switch(second->op2->variable_type){
 					case VARIABLE_TYPE_MEMORY_ADDRESS:
 					case VARIABLE_TYPE_STACK_PARAM_MEMORY_ADDRESS:
 						remediate_memory_address_variable_in_non_access_context(window, second);
@@ -2165,10 +2194,24 @@ static u_int8_t simplify_window(instruction_window_t* window){
 		 * need to do remediations here as the regular store area cannot handle that
 		 */
 		case THREE_ADDR_CODE_STORE_STATEMENT:
-		case THREE_ADDR_CODE_STORE_WITH_CONSTANT_OFFSET:
-		case THREE_ADDR_CODE_STORE_WITH_VARIABLE_OFFSET:
 			if(third->op1 != NULL){
 				switch(third->op1->variable_type){
+					case VARIABLE_TYPE_MEMORY_ADDRESS:
+					case VARIABLE_TYPE_STACK_PARAM_MEMORY_ADDRESS:
+						remediate_memory_address_variable_in_non_access_context(window, third);
+						break;
+
+					default:
+						break;
+				}
+			}
+			
+			break;
+
+		case THREE_ADDR_CODE_STORE_WITH_CONSTANT_OFFSET:
+		case THREE_ADDR_CODE_STORE_WITH_VARIABLE_OFFSET:
+			if(third->op2 != NULL){
+				switch(third->op2->variable_type){
 					case VARIABLE_TYPE_MEMORY_ADDRESS:
 					case VARIABLE_TYPE_STACK_PARAM_MEMORY_ADDRESS:
 						remediate_memory_address_variable_in_non_access_context(window, third);

--- a/oc/compiler/instruction_selector/instruction_selector.c
+++ b/oc/compiler/instruction_selector/instruction_selector.c
@@ -1346,9 +1346,78 @@ static void remediate_memory_address_variable_in_non_access_context(instruction_
 				break;
 		}
 
+		/**
+		 * There are two things that we need to account for here: regular memory address vars that
+		 * are stack local and variables that are stack passed parameters. The two take different
+		 * approaches which is why they are separated over here
+		 */
+		switch(instruction->op2->variable_type){
+			case VARIABLE_TYPE_MEMORY_ADDRESS:
+				//The additional offset may come from stack passed parameters, and we need to account for it
+				additional_offset = instruction->op2->memory_address_base_adjustment;
 
+				/**
+				 * Extract the stack offset for our use. This will determine how 
+				 * we process things down below
+				 */
+				stack_offset = var->stack_region->function_local_base_address + additional_offset;
+
+				//Make it a lea
+				if(stack_offset != 0){
+					//Emit the stack offset constant
+					three_addr_const_t* offset_constant = emit_direct_integer_or_char_constant(stack_offset, u64);
+
+					//Now the lea for our calculation
+					instruction_t* lea_statement = emit_lea_offset_only(emit_temp_var(u64), stack_pointer_variable, offset_constant);
+
+					//This lea goes in right before the store
+					insert_instruction_before_given(lea_statement, instruction);
+
+					//The op2 here is now what the lea calculated
+					instruction->op2 = lea_statement->assignee;
+
+				/**
+				 * Otherwise, we'll just swap the var out with the stack pointer since
+				 * they're one in the same. We don't need any extra instructions
+				 * before the store for this
+				 */
+				} else {
+					instruction->op2 = stack_pointer_variable;
+				}
+
+				break;
+
+			/**
+			 * A stack passed parameter address is different in a few ways. First off, we do not
+			 * know and cannot know what the actual constant value is until after register allocation.
+			 * This is a major limitation. We do however know that it will never be 0 due to the way
+			 * that the function return address is saved on the stack. We can use this to simpilify our
+			 * processing, but fundamentally we are limited here
+			 */
+			case VARIABLE_TYPE_STACK_PARAM_MEMORY_ADDRESS:
+				//Grab the additional offset for processing
+				additional_offset = instruction->op2->memory_address_base_adjustment;
+
+				//Emit the special stack constant
+				stack_offset_constant = emit_stack_passed_parameter_offset_constant(instruction->op2->associated_memory_region.stack_region, u64);
+
+				//Now emit the address calculation
+				address_instruction = emit_lea_offset_only(emit_temp_var(u64), stack_pointer_variable, stack_offset_constant);
+
+				//This goes in right before the store does
+				insert_instruction_before_given(address_instruction, instruction);
+
+				//The op1 now comes from this instruction
+				instruction->op2 = address_instruction->assignee;
+
+				break;
+
+			//This should be impossible
+			default:
+				printf("Fatal internal compiler error: invalid variable membership found in memory address remediator\n");
+				exit(1);
+		}
 	}
-
 }
 
 

--- a/oc/compiler/instruction_selector/instruction_selector.c
+++ b/oc/compiler/instruction_selector/instruction_selector.c
@@ -797,225 +797,416 @@ static void remediate_memory_address_variable_in_non_access_context(instruction_
 	three_addr_const_t* stack_offset_constant;
 	instruction_t* address_instruction;
 
-	//Grab this out
-	symtab_variable_record_t* var;
-
 	/**
 	 * If we do not have a store with offset, we grab from the op1 location. However if we
-	 * do then we need to grab from op2
+	 * do then we need to grab from op2. Since this causes such a big divergence in the flow
+	 * we will handle these two special cases separately in the else
 	 */
 	if(instruction->statement_type != THREE_ADDR_CODE_STORE_WITH_CONSTANT_OFFSET
 		&& instruction->statement_type != THREE_ADDR_CODE_LOAD_WITH_VARIABLE_OFFSET){
-		var = instruction->op1->linked_var;
+		//Extract the variable
+		symtab_variable_record_t* var = instruction->op1->linked_var;
 
-	} else {
-		var = instruction->op2->linked_var;
-	}
+		/**
+		 * Special handling if this is a global variable. Global variables will generate 2 instructions on most occassions
+		 * the lea instruction to grab the address and then the actual address manipulation in the binary operation. Note that for these steps,
+		 * window reconstruction is required
+		 *
+		 * NOTE: since this is a global variable, it is impossible for a function parameter that is passed via the stack to get caught up in this
+		 */
+		switch(var->membership){
+			case GLOBAL_VARIABLE:
+			case STATIC_VARIABLE:
+				switch(instruction->statement_type){
+					/**
+					 * A global variable address assignment like this will turn into a leaq statement
+					 */
+					case THREE_ADDR_CODE_ASSN_STMT:
+						//Let the helper emit the statement
+						address_instruction = emit_global_variable_address_calculation_oir(instruction->assignee, instruction->op1, instruction_pointer_variable);
 
-	/**
-	 * Special handling if this is a global variable. Global variables will generate 2 instructions on most occassions
-	 * the lea instruction to grab the address and then the actual address manipulation in the binary operation. Note that for these steps,
-	 * window reconstruction is required
-	 *
-	 * NOTE: since this is a global variable, it is impossible for a function parameter that is passed via the stack to get caught up in this
-	 */
-	switch(var->membership){
-		case GLOBAL_VARIABLE:
-		case STATIC_VARIABLE:
-			switch(instruction->statement_type){
+						//Insert this after the given instruction
+						insert_instruction_after_given(address_instruction, instruction);
+
+						//Once we've done that, the old instruction is useless to us
+						delete_statement(instruction);
+
+						//Rebuild the window based around the new instruction
+						reconstruct_window(window, address_instruction);
+
+						break;
+
+					/**
+					 * A global var address assignment like this will generate
+					 * 2 separate instructions. One instruction will hold the global variable address,
+					 * while the other holds the actual binary operation
+					 */
+					case THREE_ADDR_CODE_BIN_OP_STMT:
+						//Let the helper emit the statement. We will use a temp destination for this
+						address_instruction = emit_global_variable_address_calculation_oir(emit_temp_var(u64), instruction->op1, instruction_pointer_variable);
+
+						//This goes in before the given one
+						insert_instruction_before_given(address_instruction, instruction);
+
+						//We'll now replace op1 with what our assignee here is
+						instruction->op1 = address_instruction->assignee;
+
+						//And now we'll reconstruct around our instruction just ot keep the window in order
+						reconstruct_window(window, instruction);
+
+						break;
+
+					/**
+					 * A global var address like this will generate one special instruction that is RIP relative
+					 * with a constant offset
+					 */
+					case THREE_ADDR_CODE_BIN_OP_WITH_CONST_STMT:
+						//Let the helper do all of the work
+						address_instruction = emit_global_variable_address_calculation_with_offset_oir(instruction->assignee, instruction->op1, instruction_pointer_variable, instruction->op1_const);
+
+						//This goes in before the given one
+						insert_instruction_before_given(address_instruction, instruction);
+
+						//Now we can delete the old one
+						delete_statement(instruction);
+						
+						//And reconstruct the window around the new one
+						reconstruct_window(window, address_instruction);
+
+						break;
+
+					/**
+					 * For our store operations, to rememdiate we just need to do everything that we would normally do 
+					 * before the store operation and replace the op1 with what we had
+					 */
+					case THREE_ADDR_CODE_STORE_STATEMENT:
+						//Let the helper emit the statement
+						address_instruction = emit_global_variable_address_calculation_oir(emit_temp_var(u64), instruction->op1, instruction_pointer_variable);
+
+						//Put this right before the store
+						insert_instruction_before_given(address_instruction, instruction);
+
+						//The assignee here now is our op1 variable
+						instruction->op1 = address_instruction->assignee;
+
+						break;
+
+					/**
+					 * Note that values here draw from op2, not op1
+					 */
+					case THREE_ADDR_CODE_STORE_WITH_CONSTANT_OFFSET:
+					case THREE_ADDR_CODE_STORE_WITH_VARIABLE_OFFSET:
+						//Let the helper emit the statement
+						address_instruction = emit_global_variable_address_calculation_oir(emit_temp_var(u64), instruction->op2, instruction_pointer_variable);
+
+						//Put this right before the store
+						insert_instruction_before_given(address_instruction, instruction);
+
+						//The assignee here now is our op1 variable
+						instruction->op2 = address_instruction->assignee;
+
+						break;
+
+					//This should never happen
+					default:
+						printf("Fatal internal compiler error: unreachable path hit in global/static variable memory address remediation\n");
+						exit(1);
+				}
+
+				//We're completely done once we get here
+				return;
+
+			//Otherwise we get out
+			default:
+				break;
+		}
+
+		/**
+		 * There are two things that we need to account for here: regular memory address vars that
+		 * are stack local and variables that are stack passed parameters. The two take different
+		 * approaches which is why they are separated over here
+		 */
+		switch(instruction->op1->variable_type){
+			case VARIABLE_TYPE_MEMORY_ADDRESS:
+				//The additional offset may come from stack passed parameters, and we need to account for it
+				additional_offset = instruction->op1->memory_address_base_adjustment;
+
 				/**
-				 * A global variable address assignment like this will turn into a leaq statement
+				 * Extract the stack offset for our use. This will determine how 
+				 * we process things down below
 				 */
-				case THREE_ADDR_CODE_ASSN_STMT:
-					//Let the helper emit the statement
-					address_instruction = emit_global_variable_address_calculation_oir(instruction->assignee, instruction->op1, instruction_pointer_variable);
+				stack_offset = var->stack_region->function_local_base_address + additional_offset;
 
-					//Insert this after the given instruction
-					insert_instruction_after_given(address_instruction, instruction);
+				//Go based on what kind of statement that we've got here
+				switch(instruction->statement_type){
+					/**
+					 * If we have an assignment statement, we
+					 * can turn this into a lea with an offset or a
+					 * straight assignment depending on the offset
+					 */
+					case THREE_ADDR_CODE_ASSN_STMT:
+						//Make it a lea
+						if(stack_offset != 0){
+							instruction->statement_type = THREE_ADDR_CODE_LEA_STMT;
 
-					//Once we've done that, the old instruction is useless to us
-					delete_statement(instruction);
+							//Op1 becomes that stack pointer
+							instruction->op1 = stack_pointer_variable;
 
-					//Rebuild the window based around the new instruction
-					reconstruct_window(window, address_instruction);
+							//And op1_const is our offset
+							instruction->op1_const = emit_direct_integer_or_char_constant(stack_offset, u64);
+
+							//This is a lea with an offset only
+							instruction->lea_statement_type = OIR_LEA_TYPE_OFFSET_ONLY;
+
+						/**
+						 * Otherwise, we'll just swap the var out with the stack pointer since
+						 * they're one in the same
+						 */
+						} else {
+							instruction->op1 = stack_pointer_variable;
+						}
+
+						break;
+
+					/**
+					 * Store statements act very similarly to assignment statements. We
+					 * just put the store right after the memory address assignment
+					 */
+					case THREE_ADDR_CODE_STORE_STATEMENT:
+					case THREE_ADDR_CODE_STORE_WITH_CONSTANT_OFFSET:
+					case THREE_ADDR_CODE_STORE_WITH_VARIABLE_OFFSET:
+						//Make it a lea
+						if(stack_offset != 0){
+							//Emit the stack offset constant
+							three_addr_const_t* offset_constant = emit_direct_integer_or_char_constant(stack_offset, u64);
+
+							//Now the lea for our calculation
+							instruction_t* lea_statement = emit_lea_offset_only(emit_temp_var(u64), stack_pointer_variable, offset_constant);
+
+							//This lea goes in right before the store
+							insert_instruction_before_given(lea_statement, instruction);
+
+							//The op1 here is now what the lea calculated
+							instruction->op1 = lea_statement->assignee;
+
+						/**
+						 * Otherwise, we'll just swap the var out with the stack pointer since
+						 * they're one in the same. We don't need any extra instructions
+						 * before the store for this
+						 */
+						} else {
+							instruction->op1 = stack_pointer_variable;
+						}
+
+						break;
+						
+					/**
+					 * For a statement like this, we will merge the existing
+					 * constant in. We know that the only two possible operands
+					 * with a memory address are Plus/minus, so we only need to 
+					 * account for 2 cases here
+					 */
+					case THREE_ADDR_CODE_BIN_OP_WITH_CONST_STMT:
+						//Make it a lea
+						if(stack_offset != 0){
+							//Emit the constant
+							stack_offset_constant = emit_direct_integer_or_char_constant(stack_offset, i64);
+
+							//Simplify based on what we have
+							switch(instruction->op){
+								case PLUS:
+									add_constants(stack_offset_constant, instruction->op1_const);
+									break;
+
+								case MINUS:
+									subtract_constants(stack_offset_constant, instruction->op1_const);
+									break;
+
+								//This should be impossible, if we get here it's a hard out
+								default:
+									printf("Fatal internal compiler error. Attempt to do a binary operation that is not +/- with a memory address\n");
+									exit(1);
+							}
+
+							//Wipe out the operator
+							instruction->op = BLANK;
+
+							//Op1 becomes that stack pointer
+							instruction->op1 = stack_pointer_variable;
+
+							//Op1 const is the lea constant
+							instruction->op1_const = stack_offset_constant;
+
+							//Change the instruction type to a lea
+							instruction->statement_type = THREE_ADDR_CODE_LEA_STMT;
+
+							//This is an offset only
+							instruction->lea_statement_type = OIR_LEA_TYPE_OFFSET_ONLY;
+
+						/**
+						 * Otherwise, we'll just swap the var out with the stack pointer since
+						 * they're one in the same
+						 */
+						} else {
+							instruction->op1 = stack_pointer_variable;
+						}
+
+						break;
+
+					/**
+					 * Final and trickiest case. We need to have a memory calculation *and* a regular
+					 * calculation stuffed into here, but we only have 2 operands to work with. We will
+					 * need to use our special version of a lea for this in most cases
+					 */
+					case THREE_ADDR_CODE_BIN_OP_STMT:
+						//Make it a lea, we'll need to use op2
+						//for the second variable
+						if(stack_offset != 0){
+							//Create the offset constant
+							three_addr_const_t* stack_offset_constant = emit_direct_integer_or_char_constant(stack_offset, i64);
+
+							//This is now our op1_const
+							instruction->op1_const = stack_offset_constant;
+
+							//Op1 becomes the stack pointer
+							instruction->op1 = stack_pointer_variable;
+
+							//Finally declare that this is a lea statement
+							instruction->statement_type = THREE_ADDR_CODE_LEA_STMT;
+
+							//Go based on the op here
+							switch(instruction->op){
+								//In this case, we'd have something like t5 <- <offset>(t4, t5)
+								case PLUS:
+									//This is a lea statement with registers and an offset
+									instruction->lea_statement_type = OIR_LEA_TYPE_REGISTERS_AND_OFFSET;
+									
+									//Nothing else to do here
+									break;
+								
+								/**
+								 * For a minus, we'll need to circumvent the system by using a -1 multiplier
+								 * to make this still work for our lea. Since we have op1 - op2, we can rewrite
+								 * this into op1 + op2 * -1
+								 */
+								case MINUS:
+									//Full stack here
+									instruction->lea_statement_type = OIR_LEA_TYPE_REGISTERS_OFFSET_AND_SCALE;
+
+									//-1 to mimic the subtraction
+									instruction->lea_multiplier = -1;
+
+									break;
+								
+								//Unreachable path - hard fail if we somehow get to this
+								default:
+									printf("Fatal internal compiler error: Invalid binary operand found on address calculation\n");
+									exit(1);
+							}
+
+							//Wipe out the op once we're done
+							instruction->op = BLANK;
+							
+						/**
+						 * Then again all we need to do here is set the op1
+						 * to be our stack pointer
+						 */
+						} else {
+							instruction->op1 = stack_pointer_variable;
+						}
+
+						break;
+
+					//This should never happen
+					default:
+						printf("Fatal internal compiler error: unreachable path hit in memory address remediation\n");
+						exit(1);
+					}
 
 					break;
-
-				/**
-				 * A global var address assignment like this will generate
-				 * 2 separate instructions. One instruction will hold the global variable address,
-				 * while the other holds the actual binary operation
-				 */
-				case THREE_ADDR_CODE_BIN_OP_STMT:
-					//Let the helper emit the statement. We will use a temp destination for this
-					address_instruction = emit_global_variable_address_calculation_oir(emit_temp_var(u64), instruction->op1, instruction_pointer_variable);
-
-					//This goes in before the given one
-					insert_instruction_before_given(address_instruction, instruction);
-
-					//We'll now replace op1 with what our assignee here is
-					instruction->op1 = address_instruction->assignee;
-
-					//And now we'll reconstruct around our instruction just ot keep the window in order
-					reconstruct_window(window, instruction);
-
-					break;
-
-				/**
-				 * A global var address like this will generate one special instruction that is RIP relative
-				 * with a constant offset
-				 */
-				case THREE_ADDR_CODE_BIN_OP_WITH_CONST_STMT:
-					//Let the helper do all of the work
-					address_instruction = emit_global_variable_address_calculation_with_offset_oir(instruction->assignee, instruction->op1, instruction_pointer_variable, instruction->op1_const);
-
-					//This goes in before the given one
-					insert_instruction_before_given(address_instruction, instruction);
-
-					//Now we can delete the old one
-					delete_statement(instruction);
-					
-					//And reconstruct the window around the new one
-					reconstruct_window(window, address_instruction);
-
-					break;
-
-				/**
-				 * For our store operations, to rememdiate we just need to do everything that we would normally do 
-				 * before the store operation and replace the op1 with what we had
-				 */
-				case THREE_ADDR_CODE_STORE_STATEMENT:
-					//Let the helper emit the statement
-					address_instruction = emit_global_variable_address_calculation_oir(emit_temp_var(u64), instruction->op1, instruction_pointer_variable);
-
-					//Put this right before the store
-					insert_instruction_before_given(address_instruction, instruction);
-
-					//The assignee here now is our op1 variable
-					instruction->op1 = address_instruction->assignee;
-
-					break;
-
-				/**
-				 * Note that values here draw from op2, not op1
-				 */
-				case THREE_ADDR_CODE_STORE_WITH_CONSTANT_OFFSET:
-				case THREE_ADDR_CODE_STORE_WITH_VARIABLE_OFFSET:
-					//Let the helper emit the statement
-					address_instruction = emit_global_variable_address_calculation_oir(emit_temp_var(u64), instruction->op2, instruction_pointer_variable);
-
-					//Put this right before the store
-					insert_instruction_before_given(address_instruction, instruction);
-
-					//The assignee here now is our op1 variable
-					instruction->op2 = address_instruction->assignee;
-
-					break;
-
-				//This should never happen
-				default:
-					printf("Fatal internal compiler error: unreachable path hit in global/static variable memory address remediation\n");
-					exit(1);
-			}
-
-			//We're completely done once we get here
-			return;
-
-		//Otherwise we get out
-		default:
-			break;
-	}
-
-	/**
-	 * There are two things that we need to account for here: regular memory address vars that
-	 * are stack local and variables that are stack passed parameters. The two take different
-	 * approaches which is why they are separated over here
-	 */
-	switch(instruction->op1->variable_type){
-		case VARIABLE_TYPE_MEMORY_ADDRESS:
-			//The additional offset may come from stack passed parameters, and we need to account for it
-			additional_offset = instruction->op1->memory_address_base_adjustment;
 
 			/**
-			 * Extract the stack offset for our use. This will determine how 
-			 * we process things down below
+			 * A stack passed parameter address is different in a few ways. First off, we do not
+			 * know and cannot know what the actual constant value is until after register allocation.
+			 * This is a major limitation. We do however know that it will never be 0 due to the way
+			 * that the function return address is saved on the stack. We can use this to simpilify our
+			 * processing, but fundamentally we are limited here
 			 */
-			stack_offset = var->stack_region->function_local_base_address + additional_offset;
+			case VARIABLE_TYPE_STACK_PARAM_MEMORY_ADDRESS:
+				//Grab the additional offset for processing
+				additional_offset = instruction->op1->memory_address_base_adjustment;
 
-			//Go based on what kind of statement that we've got here
-			switch(instruction->statement_type){
-				/**
-				 * If we have an assignment statement, we
-				 * can turn this into a lea with an offset or a
-				 * straight assignment depending on the offset
-				 */
-				case THREE_ADDR_CODE_ASSN_STMT:
-					//Make it a lea
-					if(stack_offset != 0){
+				//Go based on what kind of statement that we've got here
+				switch(instruction->statement_type){
+					/**
+					 * Example:
+					 *   t4 <- PARAMATER_MEM<dd_0>
+					 *
+					 *   Turns into:
+					 * 	 t5 <- lea <Stack passed offset region 2>(%rsp)
+					 *
+					 */
+					case THREE_ADDR_CODE_ASSN_STMT:
+						//op1_const is our offset
+						instruction->op1_const = emit_stack_passed_parameter_offset_constant(instruction->op1->associated_memory_region.stack_region, u64);
+
+						//Add the additional offset in as an adjustment(it's usually 0)
+						instruction->op1_const->constant_adjustment = additional_offset;
+
+						//Turn it into a LEA
 						instruction->statement_type = THREE_ADDR_CODE_LEA_STMT;
 
 						//Op1 becomes that stack pointer
 						instruction->op1 = stack_pointer_variable;
 
-						//And op1_const is our offset
-						instruction->op1_const = emit_direct_integer_or_char_constant(stack_offset, u64);
-
 						//This is a lea with an offset only
 						instruction->lea_statement_type = OIR_LEA_TYPE_OFFSET_ONLY;
 
-					/**
-					 * Otherwise, we'll just swap the var out with the stack pointer since
-					 * they're one in the same
-					 */
-					} else {
-						instruction->op1 = stack_pointer_variable;
-					}
-
-					break;
-
-				/**
-				 * Store statements act very similarly to assignment statements. We
-				 * just put the store right after the memory address assignment
-				 */
-				case THREE_ADDR_CODE_STORE_STATEMENT:
-				case THREE_ADDR_CODE_STORE_WITH_CONSTANT_OFFSET:
-				case THREE_ADDR_CODE_STORE_WITH_VARIABLE_OFFSET:
-					//Make it a lea
-					if(stack_offset != 0){
-						//Emit the stack offset constant
-						three_addr_const_t* offset_constant = emit_direct_integer_or_char_constant(stack_offset, u64);
-
-						//Now the lea for our calculation
-						instruction_t* lea_statement = emit_lea_offset_only(emit_temp_var(u64), stack_pointer_variable, offset_constant);
-
-						//This lea goes in right before the store
-						insert_instruction_before_given(lea_statement, instruction);
-
-						//The op1 here is now what the lea calculated
-						instruction->op1 = lea_statement->assignee;
+						break;
 
 					/**
-					 * Otherwise, we'll just swap the var out with the stack pointer since
-					 * they're one in the same. We don't need any extra instructions
-					 * before the store for this
+					 * Store statements act very similarly to the assignment
+					 * statement, except for our need to put the assignment before the
+					 * actual statement. We do not need to account for cases where
+					 * the offset from %rsp is 0 because that will never happen
 					 */
-					} else {
-						instruction->op1 = stack_pointer_variable;
-					}
+					case THREE_ADDR_CODE_STORE_STATEMENT:
+					case THREE_ADDR_CODE_STORE_WITH_CONSTANT_OFFSET:
+					case THREE_ADDR_CODE_STORE_WITH_VARIABLE_OFFSET:
+						//Emit the special stack constant
+						stack_offset_constant = emit_stack_passed_parameter_offset_constant(instruction->op1->associated_memory_region.stack_region, u64);
 
-					break;
-					
-				/**
-				 * For a statement like this, we will merge the existing
-				 * constant in. We know that the only two possible operands
-				 * with a memory address are Plus/minus, so we only need to 
-				 * account for 2 cases here
-				 */
-				case THREE_ADDR_CODE_BIN_OP_WITH_CONST_STMT:
-					//Make it a lea
-					if(stack_offset != 0){
+						//Now emit the address calculation
+						address_instruction = emit_lea_offset_only(emit_temp_var(u64), stack_pointer_variable, stack_offset_constant);
+
+						//This goes in right before the store does
+						insert_instruction_before_given(address_instruction, instruction);
+
+						//The op1 now comes from this instruction
+						instruction->op1 = address_instruction->assignee;
+
+						break;
+
+					/**
+					 * For any binary operation instruction, we're just going to have to emit the extra assignment
+					 * here since again we cannot know what the offset is going to be
+					 *
+					 * Example:
+					 *
+					 *   t4 <- PARAMATER_MEM<dd_0> + 32
+					 *
+					 *   Turns into
+					 *
+					 * 	 t5 <- rsp + <Stack passed offset region 2>
+					 *   t4 <- t5 + 32
+					 *
+					 */
+					case THREE_ADDR_CODE_BIN_OP_WITH_CONST_STMT:
 						//Emit the constant
-						stack_offset_constant = emit_direct_integer_or_char_constant(stack_offset, i64);
+						stack_offset_constant = emit_stack_passed_parameter_offset_constant(instruction->op1->associated_memory_region.stack_region, u64);
+
+						//Add the additional offset in as an adjustment(it's usually 0)
+						stack_offset_constant->constant_adjustment = additional_offset;
 
 						//Simplify based on what we have
 						switch(instruction->op){
@@ -1048,27 +1239,20 @@ static void remediate_memory_address_variable_in_non_access_context(instruction_
 						//This is an offset only
 						instruction->lea_statement_type = OIR_LEA_TYPE_OFFSET_ONLY;
 
+
+						break;
+
 					/**
-					 * Otherwise, we'll just swap the var out with the stack pointer since
-					 * they're one in the same
+					 * Final and trickiest case. We need to have a memory calculation *and* a regular
+					 * calculation stuffed into here, but we only have 2 operands to work with. We will
+					 * need to use our special version of a lea for this in most cases
 					 */
-					} else {
-						instruction->op1 = stack_pointer_variable;
-					}
-
-					break;
-
-				/**
-				 * Final and trickiest case. We need to have a memory calculation *and* a regular
-				 * calculation stuffed into here, but we only have 2 operands to work with. We will
-				 * need to use our special version of a lea for this in most cases
-				 */
-				case THREE_ADDR_CODE_BIN_OP_STMT:
-					//Make it a lea, we'll need to use op2
-					//for the second variable
-					if(stack_offset != 0){
+					case THREE_ADDR_CODE_BIN_OP_STMT:
 						//Create the offset constant
-						three_addr_const_t* stack_offset_constant = emit_direct_integer_or_char_constant(stack_offset, i64);
+						stack_offset_constant = emit_stack_passed_parameter_offset_constant(instruction->op1->associated_memory_region.stack_region, u64);
+
+						//Add the additional offset in as an adjustment(it's usually 0)
+						stack_offset_constant->constant_adjustment = additional_offset;
 
 						//This is now our op1_const
 						instruction->op1_const = stack_offset_constant;
@@ -1111,211 +1295,31 @@ static void remediate_memory_address_variable_in_non_access_context(instruction_
 
 						//Wipe out the op once we're done
 						instruction->op = BLANK;
-						
-					/**
-					 * Then again all we need to do here is set the op1
-					 * to be our stack pointer
-					 */
-					} else {
-						instruction->op1 = stack_pointer_variable;
+
+						break;
+
+					//This should never happen
+					default:
+						printf("Fatal internal compiler error: unreachable path hit in memory address remediation\n");
+						exit(1);
 					}
-
-					break;
-
-				//This should never happen
-				default:
-					printf("Fatal internal compiler error: unreachable path hit in memory address remediation\n");
-					exit(1);
-				}
 
 				break;
 
-		/**
-		 * A stack passed parameter address is different in a few ways. First off, we do not
-		 * know and cannot know what the actual constant value is until after register allocation.
-		 * This is a major limitation. We do however know that it will never be 0 due to the way
-		 * that the function return address is saved on the stack. We can use this to simpilify our
-		 * processing, but fundamentally we are limited here
-		 */
-		case VARIABLE_TYPE_STACK_PARAM_MEMORY_ADDRESS:
-			//Grab the additional offset for processing
-			additional_offset = instruction->op1->memory_address_base_adjustment;
+			//This should be impossible
+			default:
+				printf("Fatal internal compiler error: invalid variable membership found in memory address remediator\n");
+				exit(1);
+		}
 
-			//Go based on what kind of statement that we've got here
-			switch(instruction->statement_type){
-				/**
-				 * Example:
-				 *   t4 <- PARAMATER_MEM<dd_0>
-				 *
-				 *   Turns into:
-				 * 	 t5 <- lea <Stack passed offset region 2>(%rsp)
-				 *
-				 */
-				case THREE_ADDR_CODE_ASSN_STMT:
-					//op1_const is our offset
-					instruction->op1_const = emit_stack_passed_parameter_offset_constant(instruction->op1->associated_memory_region.stack_region, u64);
-
-					//Add the additional offset in as an adjustment(it's usually 0)
-					instruction->op1_const->constant_adjustment = additional_offset;
-
-					//Turn it into a LEA
-					instruction->statement_type = THREE_ADDR_CODE_LEA_STMT;
-
-					//Op1 becomes that stack pointer
-					instruction->op1 = stack_pointer_variable;
-
-					//This is a lea with an offset only
-					instruction->lea_statement_type = OIR_LEA_TYPE_OFFSET_ONLY;
-
-					break;
-
-				/**
-				 * Store statements act very similarly to the assignment
-				 * statement, except for our need to put the assignment before the
-				 * actual statement. We do not need to account for cases where
-				 * the offset from %rsp is 0 because that will never happen
-				 */
-				case THREE_ADDR_CODE_STORE_STATEMENT:
-				case THREE_ADDR_CODE_STORE_WITH_CONSTANT_OFFSET:
-				case THREE_ADDR_CODE_STORE_WITH_VARIABLE_OFFSET:
-					//Emit the special stack constant
-					stack_offset_constant = emit_stack_passed_parameter_offset_constant(instruction->op1->associated_memory_region.stack_region, u64);
-
-					//Now emit the address calculation
-					address_instruction = emit_lea_offset_only(emit_temp_var(u64), stack_pointer_variable, stack_offset_constant);
-
-					//This goes in right before the store does
-					insert_instruction_before_given(address_instruction, instruction);
-
-					//The op1 now comes from this instruction
-					instruction->op1 = address_instruction->assignee;
-
-					break;
-
-				/**
-				 * For any binary operation instruction, we're just going to have to emit the extra assignment
-				 * here since again we cannot know what the offset is going to be
-				 *
-				 * Example:
-				 *
-				 *   t4 <- PARAMATER_MEM<dd_0> + 32
-				 *
-				 *   Turns into
-				 *
-				 * 	 t5 <- rsp + <Stack passed offset region 2>
-				 *   t4 <- t5 + 32
-				 *
-				 */
-				case THREE_ADDR_CODE_BIN_OP_WITH_CONST_STMT:
-					//Emit the constant
-					stack_offset_constant = emit_stack_passed_parameter_offset_constant(instruction->op1->associated_memory_region.stack_region, u64);
-
-					//Add the additional offset in as an adjustment(it's usually 0)
-					stack_offset_constant->constant_adjustment = additional_offset;
-
-					//Simplify based on what we have
-					switch(instruction->op){
-						case PLUS:
-							add_constants(stack_offset_constant, instruction->op1_const);
-							break;
-
-						case MINUS:
-							subtract_constants(stack_offset_constant, instruction->op1_const);
-							break;
-
-						//This should be impossible, if we get here it's a hard out
-						default:
-							printf("Fatal internal compiler error. Attempt to do a binary operation that is not +/- with a memory address\n");
-							exit(1);
-					}
-
-					//Wipe out the operator
-					instruction->op = BLANK;
-
-					//Op1 becomes that stack pointer
-					instruction->op1 = stack_pointer_variable;
-
-					//Op1 const is the lea constant
-					instruction->op1_const = stack_offset_constant;
-
-					//Change the instruction type to a lea
-					instruction->statement_type = THREE_ADDR_CODE_LEA_STMT;
-
-					//This is an offset only
-					instruction->lea_statement_type = OIR_LEA_TYPE_OFFSET_ONLY;
-
-
-					break;
-
-				/**
-				 * Final and trickiest case. We need to have a memory calculation *and* a regular
-				 * calculation stuffed into here, but we only have 2 operands to work with. We will
-				 * need to use our special version of a lea for this in most cases
-				 */
-				case THREE_ADDR_CODE_BIN_OP_STMT:
-					//Create the offset constant
-					stack_offset_constant = emit_stack_passed_parameter_offset_constant(instruction->op1->associated_memory_region.stack_region, u64);
-
-					//Add the additional offset in as an adjustment(it's usually 0)
-					stack_offset_constant->constant_adjustment = additional_offset;
-
-					//This is now our op1_const
-					instruction->op1_const = stack_offset_constant;
-
-					//Op1 becomes the stack pointer
-					instruction->op1 = stack_pointer_variable;
-
-					//Finally declare that this is a lea statement
-					instruction->statement_type = THREE_ADDR_CODE_LEA_STMT;
-
-					//Go based on the op here
-					switch(instruction->op){
-						//In this case, we'd have something like t5 <- <offset>(t4, t5)
-						case PLUS:
-							//This is a lea statement with registers and an offset
-							instruction->lea_statement_type = OIR_LEA_TYPE_REGISTERS_AND_OFFSET;
-							
-							//Nothing else to do here
-							break;
-						
-						/**
-						 * For a minus, we'll need to circumvent the system by using a -1 multiplier
-						 * to make this still work for our lea. Since we have op1 - op2, we can rewrite
-						 * this into op1 + op2 * -1
-						 */
-						case MINUS:
-							//Full stack here
-							instruction->lea_statement_type = OIR_LEA_TYPE_REGISTERS_OFFSET_AND_SCALE;
-
-							//-1 to mimic the subtraction
-							instruction->lea_multiplier = -1;
-
-							break;
-						
-						//Unreachable path - hard fail if we somehow get to this
-						default:
-							printf("Fatal internal compiler error: Invalid binary operand found on address calculation\n");
-							exit(1);
-					}
-
-					//Wipe out the op once we're done
-					instruction->op = BLANK;
-
-					break;
-
-				//This should never happen
-				default:
-					printf("Fatal internal compiler error: unreachable path hit in memory address remediation\n");
-					exit(1);
-				}
-
-			break;
-
-		//This should be impossible
-		default:
-			printf("Fatal internal compiler error: invalid variable membership found in memory address remediator\n");
-			exit(1);
+	/**
+	 * If we get here we have a store with an offset(constant or variable). They should both be handled in the same way
+	 * because the memory address var that we are after is going to be in op2 regardless
+	 */
+	} else {
+		var = instruction->op2->linked_var;
 	}
+
 }
 
 

--- a/oc/compiler/instruction_selector/instruction_selector.c
+++ b/oc/compiler/instruction_selector/instruction_selector.c
@@ -1317,7 +1317,36 @@ static void remediate_memory_address_variable_in_non_access_context(instruction_
 	 * because the memory address var that we are after is going to be in op2 regardless
 	 */
 	} else {
-		var = instruction->op2->linked_var;
+		symtab_variable_record_t* var = instruction->op2->linked_var;
+
+		/**
+		 * Special handling if this is a global variable. Global variables will generate 2 instructions on most occassions
+		 * the lea instruction to grab the address and then the actual address manipulation in the binary operation. Note that for these steps,
+		 * window reconstruction is required
+		 *
+		 * NOTE: since this is a global variable, it is impossible for a function parameter that is passed via the stack to get caught up in this
+		 */
+		switch(var->membership){
+			case GLOBAL_VARIABLE:
+			case STATIC_VARIABLE:
+				//Let the helper emit the statement
+				address_instruction = emit_global_variable_address_calculation_oir(emit_temp_var(u64), instruction->op2, instruction_pointer_variable);
+
+				//Put this right before the store
+				insert_instruction_before_given(address_instruction, instruction);
+
+				//The assignee here now is our op1 variable
+				instruction->op2 = address_instruction->assignee;
+
+				//We cna just bail out once done
+				return;
+
+			//Otherwise we get out
+			default:
+				break;
+		}
+
+
 	}
 
 }

--- a/oc/compiler/instruction_selector/instruction_selector.c
+++ b/oc/compiler/instruction_selector/instruction_selector.c
@@ -798,7 +798,19 @@ static void remediate_memory_address_variable_in_non_access_context(instruction_
 	instruction_t* address_instruction;
 
 	//Grab this out
-	symtab_variable_record_t* var = instruction->op1->linked_var;
+	symtab_variable_record_t* var;
+
+	/**
+	 * If we do not have a store with offset, we grab from the op1 location. However if we
+	 * do then we need to grab from op2
+	 */
+	if(instruction->statement_type != THREE_ADDR_CODE_STORE_WITH_CONSTANT_OFFSET
+		&& instruction->statement_type != THREE_ADDR_CODE_LOAD_WITH_VARIABLE_OFFSET){
+		var = instruction->op1->linked_var;
+
+	} else {
+		var = instruction->op2->linked_var;
+	}
 
 	/**
 	 * Special handling if this is a global variable. Global variables will generate 2 instructions on most occassions
@@ -871,12 +883,8 @@ static void remediate_memory_address_variable_in_non_access_context(instruction_
 				/**
 				 * For our store operations, to rememdiate we just need to do everything that we would normally do 
 				 * before the store operation and replace the op1 with what we had
-				 *
-				 * TODO WRONG!!!!
 				 */
 				case THREE_ADDR_CODE_STORE_STATEMENT:
-				case THREE_ADDR_CODE_STORE_WITH_CONSTANT_OFFSET:
-				case THREE_ADDR_CODE_STORE_WITH_VARIABLE_OFFSET:
 					//Let the helper emit the statement
 					address_instruction = emit_global_variable_address_calculation_oir(emit_temp_var(u64), instruction->op1, instruction_pointer_variable);
 
@@ -885,6 +893,22 @@ static void remediate_memory_address_variable_in_non_access_context(instruction_
 
 					//The assignee here now is our op1 variable
 					instruction->op1 = address_instruction->assignee;
+
+					break;
+
+				/**
+				 * Note that values here draw from op2, not op1
+				 */
+				case THREE_ADDR_CODE_STORE_WITH_CONSTANT_OFFSET:
+				case THREE_ADDR_CODE_STORE_WITH_VARIABLE_OFFSET:
+					//Let the helper emit the statement
+					address_instruction = emit_global_variable_address_calculation_oir(emit_temp_var(u64), instruction->op2, instruction_pointer_variable);
+
+					//Put this right before the store
+					insert_instruction_before_given(address_instruction, instruction);
+
+					//The assignee here now is our op1 variable
+					instruction->op2 = address_instruction->assignee;
 
 					break;
 

--- a/oc/compiler/type_system/type_system.c
+++ b/oc/compiler/type_system/type_system.c
@@ -2119,6 +2119,22 @@ generic_type_t* create_array_type(generic_type_t* points_to, u_int32_t line_numb
 
 
 /**
+ * Take in an array type and convert it to an equivalent pointer. The mutability will
+ * remain unchanged. This is meant to represent the array's decay into a pointer
+ */
+generic_type_t* convert_array_type_to_equivalent_pointer(generic_type_t* array_type){
+	//Extract the array's member type
+	generic_type_t* member_type = array_type->internal_types.member_type;
+
+	//Convert this into an array type
+	generic_type_t* resultant_array_type = create_pointer_type(member_type, array_type->line_number, array_type->mutability);
+
+	//And give it back - we will not be storing in the symtab
+	return resultant_array_type;
+}
+
+
+/**
  * Dynamically allocate and create an enumerated type
  */
 generic_type_t* create_enumerated_type(dynamic_string_t type_name, u_int32_t line_number, mutability_type_t mutability){

--- a/oc/compiler/type_system/type_system.c
+++ b/oc/compiler/type_system/type_system.c
@@ -1842,6 +1842,16 @@ generic_type_t* create_error_type(char* type_name, u_int32_t line_number){
  * Dynamically allocate and create an elaborative stack param type
  */
 generic_type_t* create_elaborative_type(generic_type_t* elaborates, u_int32_t line_number){
+	/**
+	 * If we are trying to elaborate an array type, we actually need to first convert
+	 * it to the equivalent pointer type. This will avoid any/all confusion with type
+	 * sizes
+	 */
+	if(elaborates->type_class == TYPE_CLASS_ARRAY){
+		//Convert over to a pointer
+		elaborates = convert_array_type_to_equivalent_pointer(elaborates);
+	}
+
 	//Allocate it first
 	generic_type_t* type = calloc(1, sizeof(generic_type_t));
 

--- a/oc/compiler/type_system/type_system.c
+++ b/oc/compiler/type_system/type_system.c
@@ -1867,11 +1867,19 @@ generic_type_t* create_elaborative_type(generic_type_t* elaborates, u_int32_t li
 	 * all non-pointer types, it's considered "contiguous". This means that
 	 * the memory is laid out flat, all next to eachother. If an array holds 
 	 * pointers, then this is a non-contiguous memory region
+	 *
+	 * Since arrays are always passed by pointer, they are also lumped in with
+	 * pointers in being non-contiguous
 	 */
-	if(elaborates->type_class != TYPE_CLASS_POINTER){
-		type->memory_layout_type = MEMORY_LAYOUT_TYPE_CONTIGUOUS;
-	} else {
-		type->memory_layout_type = MEMORY_LAYOUT_TYPE_NON_CONTIGUOUS;
+	switch(elaborates->type_class){
+		case TYPE_CLASS_POINTER:
+		case TYPE_CLASS_ARRAY:
+			type->memory_layout_type = MEMORY_LAYOUT_TYPE_NON_CONTIGUOUS;
+			break;
+
+		default:
+			type->memory_layout_type = MEMORY_LAYOUT_TYPE_CONTIGUOUS;
+			break;
 	}
 
 	//Give it back

--- a/oc/compiler/type_system/type_system.h
+++ b/oc/compiler/type_system/type_system.h
@@ -382,6 +382,12 @@ generic_type_t* get_referenced_type(generic_type_t* starting_type, u_int16_t ind
 generic_type_t* create_array_type(generic_type_t* points_to, u_int32_t line_number, u_int32_t num_members, mutability_type_t mutability);
 
 /**
+ * Take in an array type and convert it to an equivalent pointer. The mutability will
+ * remain unchanged. This is meant to represent the array's decay into a pointer
+ */
+generic_type_t* convert_array_type_to_equivalent_pointer(generic_type_t* array_type);
+
+/**
  * Dynamically allocate and create an aliased type
  */
 generic_type_t* create_aliased_type(char* type_name, generic_type_t* aliased_type, u_int32_t line_number, mutability_type_t mutability);

--- a/oc/test_files/elaborative_param_arrays.ol
+++ b/oc/test_files/elaborative_param_arrays.ol
@@ -1,0 +1,25 @@
+/**
+* Author: Jack Robbins
+* Handle the case where we are using an elaborative param of arrays(valid case)
+*/
+
+pub fn elaborative_param_arrays(arr_of_arr:params i32[4]) -> i32 {
+	let result:mut i32 = 0;
+
+	for(let i:mut i32 = 0; i < paramcount(arr_of_arr); i++){
+		result += arr_of_arr[i][1];
+	}
+
+	ret result;
+}
+
+
+pub fn main() -> i32 {	
+	let arr1:i32[] = [1, 2, 3, 4];
+	let arr2:i32[] = [1, 3, 3, 4];
+	let arr3:i32[] = [1, 4, 3, 4];
+	let arr4:i32[] = [1, 5, 3, 4];
+
+	//Should return 2 + 3 + 4 + 5 = 14
+	ret @elaborative_param_arrays(arr1, arr2, arr3, arr4);
+}

--- a/oc/test_files/elaborative_param_of_arrays.ol
+++ b/oc/test_files/elaborative_param_of_arrays.ol
@@ -1,0 +1,27 @@
+/**
+* Author: Jack Robbins
+* Test a super edgecase where someone is passing in pointers as elaborative params
+* and then attempting to dereference them all in one go
+*/
+
+
+pub fn elaborative_param_of_arrays(x:i32, y:params mut i32[4]) -> i32 {
+	let result:mut i32 = x;
+
+	for(let i:mut i32 = 0; i < paramcount(y); i++) {
+		result += y[i][0] + y[i][1];
+	}
+
+	ret result;
+}
+
+
+//Call into this function
+pub fn main() -> i32 {
+	let x:mut i32[4] = [1, 2, 3, 4];
+	let y:mut i32[4] = [3, 6, 7, 10];
+	let z:mut i32[4] = [4, 5, 8, 9];
+
+	//Should return - 0 + (1 + 2) + (3 + 6) + (4 + 5) = 21
+	ret @elaborative_param_of_arrays(0, x, y, z);
+}

--- a/oc/test_files/elaborative_param_of_pointers.ol
+++ b/oc/test_files/elaborative_param_of_pointers.ol
@@ -1,0 +1,27 @@
+/**
+* Author: Jack Robbins
+* Test a super edgecase where someone is passing in pointers as elaborative params
+* and then attempting to dereference them all in one go
+*/
+
+
+pub fn elaborative_param_of_pointers(x:i32, y:params mut i32*) -> i32 {
+	let result:mut i32 = x;
+
+	for(let i:mut i32 = 0; i < paramcount(y); i++) {
+		result += y[i][0] + y[i][1];
+	}
+
+	ret result;
+}
+
+
+//Call into this function
+pub fn main() -> i32 {
+	let x:mut i32[4] = [1, 2, 3, 4];
+	let y:mut i32[4] = [3, 6, 7, 10];
+	let z:mut i32[4] = [4, 5, 8, 9];
+
+	//Should return - 0 + (1 + 2) + (3 + 6) + (4 + 5) = 21
+	ret @elaborative_param_of_pointers(0, x, y, z);
+}


### PR DESCRIPTION
[CFG]: add support for array, pointer types inside of elaborative parameters

Closes #884 
Closes #894 
Closes #895 
Closes #897 
Closes #898 