### PR TITLE
[Parser]: Enable memory copying from within ternary expressions

### DIFF
--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -167,6 +167,59 @@ static inline u_int8_t does_enum_contain_integer_member(generic_type_t* enum_typ
 
 
 /**
+ * Propogate the dereference needed flag down recursively until we hit a postfix
+ * expression(our "root" in this case) or nothing. This is important because we cannot
+ * be dereferencing if we need to perform a copy assignment
+ *
+ * NOTE: This method is recursive which is why we are not inlining it
+ */
+static void flag_no_dereference_needed(generic_ast_node_t* node){
+	//Base case - we have nothing so just leave
+	if(node == NULL){
+		return;
+	}
+
+	generic_ast_node_t* ternary_cursor;
+
+	switch(node->ast_node_type){
+		/**
+		 * For a ternary expression we need to flag the left and right children
+		 * as not requiring any kind of dereference
+		 */
+		case AST_NODE_TYPE_TERNARY_EXPRESSION:
+			//First we have the expression
+			ternary_cursor = node->first_child;
+
+			//Then the left child which we flag first
+			ternary_cursor = ternary_cursor->next_sibling;
+
+			//Flag the left child first
+			flag_no_dereference_needed(ternary_cursor);
+
+			//Now advance to the right child
+			ternary_cursor = ternary_cursor->next_sibling;
+
+			//And flag the right child
+			flag_no_dereference_needed(ternary_cursor);
+
+			return;
+
+		/**
+		 * Flag here that we do not need a dereference on the 
+		 * postfix expression if we have one
+		 */
+		case AST_NODE_TYPE_POSTFIX_EXPR:
+			node->dereference_needed = FALSE;
+			return;
+
+		//Whatever this is we aren't interested
+		default:
+			return;
+	}
+}
+
+
+/**
  * Is a given variable a data segment variable? These variables are not actually
  * stored in registers or in memory so we need to treat them a bit differently. In
  * ollie only static and global variables fit the bill for this
@@ -1643,6 +1696,7 @@ static inline generic_ast_node_t* handle_elaborative_param_parsing(ollie_token_s
 				 * to perform a memory copy assignment here, we need to flag that 
 				 * we do *not* require a dereference to make this work
 				 */
+
 				switch(elaborated_param->ast_node_type){
 					case AST_NODE_TYPE_POSTFIX_EXPR:
 						elaborated_param->dereference_needed = FALSE;
@@ -11781,10 +11835,6 @@ static generic_type_t* validate_initializer_types(generic_type_t* target_type, g
 				return NULL;
 			}
 
-			if(initializer_node->ast_node_type == AST_NODE_TYPE_TERNARY_EXPRESSION){
-				printf("HERE\n\n\n");
-			}
-
 			//Use the helper to determine if the types are assignable
 			generic_type_t* final_type = types_assignable(return_type, initializer_node->inferred_type);
 
@@ -11835,57 +11885,6 @@ static inline u_int8_t is_initializer_node(generic_ast_node_t* initializer_node)
 			return TRUE;
 		default:
 			return FALSE;
-	}
-}
-
-
-/**
- * Propogate the dereference needed flag down recursively until we hit a postfix
- * expression(our "root" in this case) or nothing. This is important because we cannot
- * be dereferencing if we need to perform a copy assignment
- *
- * NOTE: This method is recursive which is why we are not inlining it
- */
-static void flag_no_dereference_needed(generic_ast_node_t* node){
-	//Base case - we have nothing so just leave
-	if(node == NULL){
-		return;
-	}
-
-	generic_ast_node_t* ternary_cursor;
-
-	switch(node->ast_node_type){
-		/**
-		 */
-		case AST_NODE_TYPE_TERNARY_EXPRESSION:
-			//First we have the expression
-			ternary_cursor = node->first_child;
-
-			//Then the left child which we flag first
-			ternary_cursor = ternary_cursor->next_sibling;
-
-			//Flag the left child first
-			flag_no_dereference_needed(ternary_cursor);
-
-			//Now advance to the right child
-			ternary_cursor = ternary_cursor->next_sibling;
-
-			//And flag the right child
-			flag_no_dereference_needed(ternary_cursor);
-
-			return;
-
-		/**
-		 * Flag here that we do not need a dereference on the 
-		 * postfix expression if we have one
-		 */
-		case AST_NODE_TYPE_POSTFIX_EXPR:
-			node->dereference_needed = FALSE;
-			return;
-
-		//Whatever this is we aren't interested
-		default:
-			return;
 	}
 }
 
@@ -12039,36 +12038,7 @@ static generic_ast_node_t* let_statement(ollie_token_stream_t* token_stream, u_i
 		 * expression(our "root" in this case) or nothing. This is important because we cannot
 		 * be dereferencing if we need to perform a copy assignment
 		 */
-		flag_no_dereference_required(initializer_node);
-
-
-		printf("HERE\n\n\n");
-		/**
-		 * If the right hand expression is a postfix expression *and* we are looking
-		 * to perform a memory copy assignment here, we need to flag that 
-		 * we do *not* require a dereference to make this work
-		 */
-		switch(initializer_node->ast_node_type){
-			case AST_NODE_TYPE_POSTFIX_EXPR:
-				initializer_node->dereference_needed = FALSE;
-				break;
-
-			/**
-			 * Copy assignment through ternaries produce undefined behavior
-			 *
-			 * This is unstable
-			 */
-			case AST_NODE_TYPE_TERNARY_EXPRESSION:
-				initializer_node->dereference_needed = FALSE;
-
-				//This is unstable
-				print_parse_message(MESSAGE_TYPE_WARNING, "Copy assignment through ternary produces undefined behavior", parser_line_num);
-				num_warnings++;
-				break;
-
-			default:
-				break;
-		}
+		flag_no_dereference_needed(initializer_node);
 
 		//Store the bytes that we need to copy here
 		let_stmt_node->optional_storage.bytes_to_copy = type_spec->type_size; 

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -173,7 +173,7 @@ static inline u_int8_t does_enum_contain_integer_member(generic_type_t* enum_typ
  *
  * NOTE: This method is recursive which is why we are not inlining it
  */
-static void flag_no_dereference_needed(generic_ast_node_t* node){
+static void propogate_no_dereference_required_flag(generic_ast_node_t* node){
 	//Base case - we have nothing so just leave
 	if(node == NULL){
 		return;
@@ -194,13 +194,13 @@ static void flag_no_dereference_needed(generic_ast_node_t* node){
 			ternary_cursor = ternary_cursor->next_sibling;
 
 			//Flag the left child first
-			flag_no_dereference_needed(ternary_cursor);
+			propogate_no_dereference_required_flag(ternary_cursor);
 
 			//Now advance to the right child
 			ternary_cursor = ternary_cursor->next_sibling;
 
 			//And flag the right child
-			flag_no_dereference_needed(ternary_cursor);
+			propogate_no_dereference_required_flag(ternary_cursor);
 
 			return;
 
@@ -1696,7 +1696,7 @@ static inline generic_ast_node_t* handle_elaborative_param_parsing(ollie_token_s
 				 * to perform a memory copy assignment here, we need to flag that 
 				 * we do *not* require a dereference to make this work
 				 */
-				flag_no_dereference_needed(elaborated_param);
+				propogate_no_dereference_required_flag(elaborated_param);
 			}
 
 			/**
@@ -2190,7 +2190,7 @@ static generic_ast_node_t* function_call(ollie_token_stream_t* token_stream, sid
 					 * to perform a memory copy assignment here, we need to flag that 
 					 * we do *not* require a dereference to make this work
 					 */
-					flag_no_dereference_needed(current_param);
+					propogate_no_dereference_required_flag(current_param);
 				}
 
 				//Special checking here - if we have an enum type that is being assigned to, we need
@@ -3284,14 +3284,14 @@ loop_end:
 			 * to perform a memory copy assignment here, we need to flag that 
 			 * we do *not* require a dereference to make this work
 			 */
-			flag_no_dereference_needed(left_hand_unary);
+			propogate_no_dereference_required_flag(left_hand_unary);
 
 			/**
 			 * If the right hand expression is a postfix expression *and* we are looking
 			 * to perform a memory copy assignment here, we need to flag that 
 			 * we do *not* require a dereference to make this work
 			 */
-			flag_no_dereference_needed(expr);
+			propogate_no_dereference_required_flag(expr);
 
 			//Store this for down the road - how many bytes do we need to copy
 			asn_expr_node->optional_storage.bytes_to_copy = final_type->type_size;
@@ -11977,7 +11977,7 @@ static generic_ast_node_t* let_statement(ollie_token_stream_t* token_stream, u_i
 		 * expression(our "root" in this case) or nothing. This is important because we cannot
 		 * be dereferencing if we need to perform a copy assignment
 		 */
-		flag_no_dereference_needed(initializer_node);
+		propogate_no_dereference_required_flag(initializer_node);
 
 		//Store the bytes that we need to copy here
 		let_stmt_node->optional_storage.bytes_to_copy = type_spec->type_size; 

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -2161,8 +2161,11 @@ static generic_ast_node_t* function_call(ollie_token_stream_t* token_stream, sid
 						case AST_NODE_TYPE_POSTFIX_EXPR:
 							current_param->dereference_needed = FALSE;
 							break;
+
 						/**
 						 * Copy assignment through ternaries produce undefined behavior
+						 *
+						 * TODO COMPLETELY UNTESTED
 						 */
 						case AST_NODE_TYPE_TERNARY_EXPRESSION:
 							current_param->dereference_needed = FALSE;
@@ -6393,8 +6396,6 @@ static generic_ast_node_t* ternary_expression(ollie_token_stream_t* token_stream
 
 	//Determine the compatibility of these ternary nodes, and coerce it
 	ternary_expression_node->inferred_type = determine_compatibility_and_coerce(type_symtab, &(if_branch->inferred_type), &(else_branch->inferred_type), QUESTION);
-
-	if(ternary_expression_node->inferred_type == NULL)printf("HERE\n\n\n");
 
 	//A ternary is not assignable
 	ternary_expression_node->is_assignable = FALSE;
@@ -11839,6 +11840,57 @@ static inline u_int8_t is_initializer_node(generic_ast_node_t* initializer_node)
 
 
 /**
+ * Propogate the dereference needed flag down recursively until we hit a postfix
+ * expression(our "root" in this case) or nothing. This is important because we cannot
+ * be dereferencing if we need to perform a copy assignment
+ *
+ * NOTE: This method is recursive which is why we are not inlining it
+ */
+static void flag_no_dereference_needed(generic_ast_node_t* node){
+	//Base case - we have nothing so just leave
+	if(node == NULL){
+		return;
+	}
+
+	generic_ast_node_t* ternary_cursor;
+
+	switch(node->ast_node_type){
+		/**
+		 */
+		case AST_NODE_TYPE_TERNARY_EXPRESSION:
+			//First we have the expression
+			ternary_cursor = node->first_child;
+
+			//Then the left child which we flag first
+			ternary_cursor = ternary_cursor->next_sibling;
+
+			//Flag the left child first
+			flag_no_dereference_needed(ternary_cursor);
+
+			//Now advance to the right child
+			ternary_cursor = ternary_cursor->next_sibling;
+
+			//And flag the right child
+			flag_no_dereference_needed(ternary_cursor);
+
+			return;
+
+		/**
+		 * Flag here that we do not need a dereference on the 
+		 * postfix expression if we have one
+		 */
+		case AST_NODE_TYPE_POSTFIX_EXPR:
+			node->dereference_needed = FALSE;
+			return;
+
+		//Whatever this is we aren't interested
+		default:
+			return;
+	}
+}
+
+
+/**
  * A let statement is always the child of an overall declaration statement. Like a declare statement, it also
  * performs type checking and inference and all needed symbol table manipulation
  *
@@ -11982,6 +12034,14 @@ static generic_ast_node_t* let_statement(ollie_token_stream_t* token_stream, u_i
 	 */
 	if(is_initializer_node(initializer_node) == FALSE
 		&& is_copy_assignment_required(type_spec, initializer_node->inferred_type) == TRUE){
+		/**
+		 * Propogate the dereference needed flag down recursively until we hit a postfix
+		 * expression(our "root" in this case) or nothing. This is important because we cannot
+		 * be dereferencing if we need to perform a copy assignment
+		 */
+		flag_no_dereference_required(initializer_node);
+
+
 		printf("HERE\n\n\n");
 		/**
 		 * If the right hand expression is a postfix expression *and* we are looking

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -6392,6 +6392,8 @@ static generic_ast_node_t* ternary_expression(ollie_token_stream_t* token_stream
 	//Determine the compatibility of these ternary nodes, and coerce it
 	ternary_expression_node->inferred_type = determine_compatibility_and_coerce(type_symtab, &(if_branch->inferred_type), &(else_branch->inferred_type), QUESTION);
 
+	if(ternary_expression_node->inferred_type == NULL)printf("HERE\n\n\n");
+
 	//A ternary is not assignable
 	ternary_expression_node->is_assignable = FALSE;
 
@@ -11774,6 +11776,10 @@ static generic_type_t* validate_initializer_types(generic_type_t* target_type, g
 				sprintf(info, "Type \"%s\" may only be initialized using the appropriate initializer list syntax", target_type->type_name.string);
 				print_parse_message(MESSAGE_TYPE_ERROR, info, parser_line_num);
 				return NULL;
+			}
+
+			if(initializer_node->ast_node_type == AST_NODE_TYPE_TERNARY_EXPRESSION){
+				printf("HERE\n\n\n");
 			}
 
 			//Use the helper to determine if the types are assignable

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -113,7 +113,7 @@ static generic_ast_node_t* raise_statement(ollie_token_stream_t* token_stream);
 static u_int8_t error_list(ollie_token_stream_t* token_stream, generic_type_t* function_type, u_int8_t defining_predeclared_function);
 //Definition is a special compiler-directive, it's executed here, and as such does not produce any nodes
 static u_int8_t definition(ollie_token_stream_t* token_stream, u_int8_t in_global_scope);
-static generic_type_t* validate_intializer_types(generic_type_t* target_type, generic_ast_node_t* initializer_node, variable_membership_t membership);
+static generic_type_t* validate_initializer_types(generic_type_t* target_type, generic_ast_node_t* initializer_node, variable_membership_t membership);
 static inline generic_type_t* handle_elaborative_param_type(generic_type_t* elaborated_type);
 static u_int8_t validate_function_parameter_list(generic_type_t* function_type);
 
@@ -11490,7 +11490,7 @@ static u_int8_t validate_types_for_array_initializer_list(generic_type_t* array_
 	//to the given array type
 	while(cursor != NULL){
 		//We'll use the same top level initialization check for this rule as well
-		generic_type_t* final_type = validate_intializer_types(member_type, cursor, membership);
+		generic_type_t* final_type = validate_initializer_types(member_type, cursor, membership);
 
 		//If these fail, then we're done here. No need for an error message, they'll have already been
 		//printed
@@ -11565,7 +11565,7 @@ static u_int8_t validate_types_for_struct_initializer_list(generic_type_t* struc
 		symtab_variable_record_t* variable = dynamic_array_get_at(&struct_table, seen_count);
 
 		//Recursively call the initializer processor rule. This allows us to handle nested initializations
-		generic_type_t* final_type = validate_intializer_types(variable->type_defined_as, cursor, membership);
+		generic_type_t* final_type = validate_initializer_types(variable->type_defined_as, cursor, membership);
 
 		//Let's check to see if the types are assignable
 		if(final_type == NULL){
@@ -11652,7 +11652,7 @@ static generic_ast_node_t* validate_or_set_bounds_for_string_initializer(generic
 /**
  * Top level initializer value for type validation
  */
-static generic_type_t* validate_intializer_types(generic_type_t* target_type, generic_ast_node_t* initializer_node, variable_membership_t membership){
+static generic_type_t* validate_initializer_types(generic_type_t* target_type, generic_ast_node_t* initializer_node, variable_membership_t membership){
 	//Dealias this just to be safe
 	target_type = dealias_type(target_type);
 
@@ -11719,10 +11719,13 @@ static generic_type_t* validate_intializer_types(generic_type_t* target_type, ge
 			
 		//Otherwise we'll just take the standard path
 		default:
-			//If we have a string constant, there's a chance that we could be seeing a string
-			//initializer of the form let a:char[] := "Hi";. If that's the case, we'll let
-			//the helper deal with it
-			if(initializer_node->ast_node_type == AST_NODE_TYPE_CONSTANT && initializer_node->constant_type == STR_CONST
+			/**
+			 * If we have a string constant, there's a chance that we could be seeing a string
+			 * initializer of the form let a:char[] := "Hi";. If that's the case, we'll let
+			 * the helper deal with it
+			 */
+			if(initializer_node->ast_node_type == AST_NODE_TYPE_CONSTANT 
+				&& initializer_node->constant_type == STR_CONST
 				&& target_type->type_class == TYPE_CLASS_ARRAY){
 				
 				//Dynamically set the initializer node here in the helper function
@@ -11734,8 +11737,10 @@ static generic_type_t* validate_intializer_types(generic_type_t* target_type, ge
 					return NULL;
 				}
 
-				//Otherwise we'll just break out. The initializer node will have been properly
-				//set by the function above
+				/**
+				 * Otherwise we'll just break out. The initializer node will have been properly
+				 * set by the function above
+				 */
 				return return_type;
 			}
 
@@ -11944,7 +11949,7 @@ static generic_ast_node_t* let_statement(ollie_token_stream_t* token_stream, u_i
 	 * Store the return type here after we do all needed validations. This rule allows 
 	 * for recursive validation, so that we can handle recursive initialization
 	 */
-	generic_type_t* return_type = validate_intializer_types(type_spec, initializer_node, membership);
+	generic_type_t* return_type = validate_initializer_types(type_spec, initializer_node, membership);
 
 	//If the return type is NULL, we fail out here
 	if(return_type == NULL){
@@ -11969,6 +11974,7 @@ static generic_ast_node_t* let_statement(ollie_token_stream_t* token_stream, u_i
 	 */
 	if(is_initializer_node(initializer_node) == FALSE
 		&& is_copy_assignment_required(type_spec, initializer_node->inferred_type) == TRUE){
+		printf("HERE\n\n\n");
 		/**
 		 * If the right hand expression is a postfix expression *and* we are looking
 		 * to perform a memory copy assignment here, we need to flag that 
@@ -11981,6 +11987,8 @@ static generic_ast_node_t* let_statement(ollie_token_stream_t* token_stream, u_i
 
 			/**
 			 * Copy assignment through ternaries produce undefined behavior
+			 *
+			 * This is unstable
 			 */
 			case AST_NODE_TYPE_TERNARY_EXPRESSION:
 				initializer_node->dereference_needed = FALSE;

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -1696,28 +1696,7 @@ static inline generic_ast_node_t* handle_elaborative_param_parsing(ollie_token_s
 				 * to perform a memory copy assignment here, we need to flag that 
 				 * we do *not* require a dereference to make this work
 				 */
-
-				switch(elaborated_param->ast_node_type){
-					case AST_NODE_TYPE_POSTFIX_EXPR:
-						elaborated_param->dereference_needed = FALSE;
-						break;
-
-					/**
-					 * Copy assignment through ternaries produce undefined behavior
-					 *
-					 * TODO WOULD NEED SOME KIND OF WAY TO PROPOGATE THE DEREF NEEDED FLAG
-					 */
-					case AST_NODE_TYPE_TERNARY_EXPRESSION:
-						elaborated_param->dereference_needed = FALSE;
-
-						//This is unstable
-						print_parse_message(MESSAGE_TYPE_WARNING, "Copy assignment through ternary produces undefined behavior", parser_line_num);
-						num_warnings++;
-						break;
-
-					default:
-						break;
-				}
+				flag_no_dereference_needed(elaborated_param);
 			}
 
 			/**
@@ -2211,27 +2190,7 @@ static generic_ast_node_t* function_call(ollie_token_stream_t* token_stream, sid
 					 * to perform a memory copy assignment here, we need to flag that 
 					 * we do *not* require a dereference to make this work
 					 */
-					switch(current_param->ast_node_type){
-						case AST_NODE_TYPE_POSTFIX_EXPR:
-							current_param->dereference_needed = FALSE;
-							break;
-
-						/**
-						 * Copy assignment through ternaries produce undefined behavior
-						 *
-						 * TODO COMPLETELY UNTESTED
-						 */
-						case AST_NODE_TYPE_TERNARY_EXPRESSION:
-							current_param->dereference_needed = FALSE;
-
-							//This is unstable
-							print_parse_message(MESSAGE_TYPE_WARNING, "Copy assignment through ternary produces undefined behavior", parser_line_num);
-							num_warnings++;
-							break;
-
-						default:
-							break;
-					}
+					flag_no_dereference_needed(current_param);
 				}
 
 				//Special checking here - if we have an enum type that is being assigned to, we need
@@ -3325,34 +3284,14 @@ loop_end:
 			 * to perform a memory copy assignment here, we need to flag that 
 			 * we do *not* require a dereference to make this work
 			 */
-			if(left_hand_unary->ast_node_type == AST_NODE_TYPE_POSTFIX_EXPR){
-				left_hand_unary->dereference_needed = FALSE;
-			}
+			flag_no_dereference_needed(left_hand_unary);
 
 			/**
 			 * If the right hand expression is a postfix expression *and* we are looking
 			 * to perform a memory copy assignment here, we need to flag that 
 			 * we do *not* require a dereference to make this work
 			 */
-			switch(expr->ast_node_type){
-				case AST_NODE_TYPE_POSTFIX_EXPR:
-					expr->dereference_needed = FALSE;
-					break;
-
-				/**
-				 * Copy assignment through ternaries produce undefined behavior
-				 */
-				case AST_NODE_TYPE_TERNARY_EXPRESSION:
-					expr->dereference_needed = FALSE;
-
-					//This is unstable
-					print_parse_message(MESSAGE_TYPE_WARNING, "Copy assignment through ternary produces undefined behavior", parser_line_num);
-					num_warnings++;
-					break;
-
-				default:
-					break;
-			}
+			flag_no_dereference_needed(expr);
 
 			//Store this for down the road - how many bytes do we need to copy
 			asn_expr_node->optional_storage.bytes_to_copy = final_type->type_size;

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -1650,6 +1650,8 @@ static inline generic_ast_node_t* handle_elaborative_param_parsing(ollie_token_s
 
 					/**
 					 * Copy assignment through ternaries produce undefined behavior
+					 *
+					 * TODO WOULD NEED SOME KIND OF WAY TO PROPOGATE THE DEREF NEEDED FLAG
 					 */
 					case AST_NODE_TYPE_TERNARY_EXPRESSION:
 						elaborated_param->dereference_needed = FALSE;

--- a/oc/compiler/type_system/type_system.c
+++ b/oc/compiler/type_system/type_system.c
@@ -1253,6 +1253,30 @@ generic_type_t* determine_compatibility_and_coerce(void* symtab, generic_type_t*
 		 * Very unique case - ternary operator
 		 */
 		case QUESTION:
+			/**
+			 * For structs/unions, we can copy them over to eachother but they'll have
+			 * to be the *exact* same type if we do
+			 */
+			if((*a)->type_class == TYPE_CLASS_STRUCT){
+				if(*a != *b){
+					return NULL;
+				} else {
+					return *a;
+				}
+			}
+
+			/**
+			 * Exact same situation for a union type class - they'll need to be the
+			 * exact same or else we aren't having it
+			 */
+			if((*a)->type_class == TYPE_CLASS_UNION){
+				if(*a != *b){
+					return NULL;
+				} else {
+					return *a;
+				}
+			}
+
 			//If a is a pointer type
 			if((*a)->type_class == TYPE_CLASS_POINTER){
 				//If b is a another pointer, then that's fine

--- a/oc/compiler/type_system/type_system.c
+++ b/oc/compiler/type_system/type_system.c
@@ -1255,25 +1255,34 @@ generic_type_t* determine_compatibility_and_coerce(void* symtab, generic_type_t*
 		case QUESTION:
 			/**
 			 * For structs/unions, we can copy them over to eachother but they'll have
-			 * to be the *exact* same type if we do
+			 * to be they have to be assignable to one another
 			 */
-			if((*a)->type_class == TYPE_CLASS_STRUCT){
-				if(*a != *b){
-					return NULL;
-				} else {
-					return *a;
-				}
-			}
+			if((*a)->type_class == TYPE_CLASS_STRUCT || (*a)->type_class == TYPE_CLASS_UNION){
+				/**
+				 * If either way works(a to b or b to a), we will then go through and
+				 * perform mutability coercion on the two types. Mutability coercion
+				 * will ensure that we are maintaining the lowest level of mutability
+				 */
+				if(types_assignable(*a, *b) != NULL || types_assignable(*b, *a) != NULL){
+					/**
+					 * If a is mutable, then this all hinges on b being mutable or not. If 
+					 * b is also mutable, then we will have a mutable type. But if b is not
+					 * mutable, then we will have an immutable type. Either way it hinges
+					 * on b, so we just return b in the end regardless
+					 */
+					if((*a)->mutability == MUTABLE){
+						return *b;
 
-			/**
-			 * Exact same situation for a union type class - they'll need to be the
-			 * exact same or else we aren't having it
-			 */
-			if((*a)->type_class == TYPE_CLASS_UNION){
-				if(*a != *b){
-					return NULL;
+					/**
+					 * It's not mutable. Whatever b's mutability is, we preserve the lowest
+					 * mutability level which in this case is a's, so we return that
+					 */
+					} else {
+						return *a;
+					}
+
 				} else {
-					return *a;
+					return NULL;
 				}
 			}
 

--- a/oc/test_files/copy_struct_ternary.ol
+++ b/oc/test_files/copy_struct_ternary.ol
@@ -1,0 +1,32 @@
+/**
+* Author: Jack Robbins
+* Test case where we have a ternary struct copy
+*/
+
+define struct custom {
+	x:i32;
+	y:i32;
+	z:f64;
+	ch:char;
+} as small_struct;
+
+
+/**
+* Simple tester for copying structs via a ternary expression
+*/
+pub fn copy_structs_ternary(x:i32) -> i32 {
+	let original1:small_struct = {1, 5, 3.33d, 'a'};
+	let original2:small_struct = {2, 6, 4.44d, 'b'};
+
+	//Triggers a ternary
+	let copy:small_struct = (x > 2) ? original1 else original2;
+
+	ret copy:x + copy:y
+}
+
+
+
+pub fn main() -> i32 {
+	//Should return 1 + 5 = 6
+	ret @copy_structs_ternary(3);
+}

--- a/oc/test_files/copy_struct_ternary_assignment.ol
+++ b/oc/test_files/copy_struct_ternary_assignment.ol
@@ -15,11 +15,13 @@ define struct custom {
 * Simple tester for copying structs via a ternary expression
 */
 pub fn copy_structs_ternary(x:i32) -> i32 {
+	declare copy:mut small_struct;
+
 	let original1:small_struct = {1, 5, 3.33d, 'a'};
 	let original2:small_struct = {2, 6, 4.44d, 'b'};
 
-	//Triggers a ternary
-	let copy:small_struct = (x > 2) ? original1 else original2;
+	//Triggers a ternary copy
+	copy = (x > 2) ? original1 else original2;
 
 	ret copy:x + copy:y;
 }

--- a/oc/test_files/copy_struct_ternary_assignment_mutability_check.ol
+++ b/oc/test_files/copy_struct_ternary_assignment_mutability_check.ol
@@ -1,0 +1,36 @@
+/**
+* Author: Jack Robbins
+* Test case where we have a ternary struct copy
+*/
+
+define struct custom {
+	x:i32;
+	y:i32;
+	z:f64;
+	ch:char;
+} as small_struct;
+
+
+/**
+* Simple tester for copying structs via a ternary expression
+*/
+pub fn copy_structs_ternary(x:i32) -> i32 {
+	let original1:mut small_struct = {1, 5, 3.33d, 'a'};
+	let original2:small_struct = {2, 6, 4.44d, 'b'};
+
+	/**
+	 * Trigger a ternary copy. This should work because
+	 * we always cast to the lowest possible mutability level,
+	 * so we should be able to assign properly here
+	 */
+	let copy:small_struct = (x > 2) ? original1 else original2;
+
+	ret copy:x + copy:y;
+}
+
+
+
+pub fn main() -> i32 {
+	//Should return 1 + 5 = 6
+	ret @copy_structs_ternary(3);
+}

--- a/oc/test_files/nested_struct_copy_as_param.ol
+++ b/oc/test_files/nested_struct_copy_as_param.ol
@@ -1,0 +1,38 @@
+/**
+* Author: Jack Robbins
+* Test the case where we are assigning(copying) a struct that is nested inside of another struct. This
+* specifically tests the case where we're copying on both the left and right hand sides so it is
+* most complex than usual
+*/
+
+define struct inner {
+	x:i32;
+	y:f64;
+} as inner_struct;
+
+
+define struct outer {
+	x:i32[5];
+	nested_inner:mut inner_struct;
+	holder:i32;
+} as outer_struct;
+
+
+//Pass by copy, returns 3 * x
+pub fn my_fn(param:inner_struct) -> i32 {
+	ret 3 * param:x;
+}
+
+
+pub fn main() -> i32 {
+	let outer1:mut outer_struct = {[1, 2, 3, 4, 5], {1, 2.0}, 5};
+	let outer2:mut outer_struct = {[1, 2, 3, 4, 5], {5, 5.0d}, 5};
+
+	let x:i32 = 5;
+
+	/**
+	 * Use the ternary struct assignment as the parameter 
+	 * Should return 5 * 3 = 15
+	 */
+	ret @my_fn((x > 5 ? outer1:nested_inner else outer2:nested_inner));
+}

--- a/oc/test_files/nested_struct_copy_double_ternary_let.ol
+++ b/oc/test_files/nested_struct_copy_double_ternary_let.ol
@@ -1,0 +1,47 @@
+/**
+* Author: Jack Robbins
+* Test an absurdly complex case where we have a nested ternary that is with a struct copy. Honestly
+* if anyone is doing I would be surprised but we still need to support this out of the box
+*/
+
+define struct inner {
+	x:i32;
+	y:f64;
+} as inner_struct;
+
+
+define struct outer {
+	x:i32[5];
+	nested_inner:mut inner_struct;
+	holder:i32;
+} as outer_struct;
+
+
+//Pass by copy, returns 3 * x
+pub fn my_fn(param:inner_struct) -> i32 {
+	ret 3 * param:x;
+}
+
+
+pub fn main() -> i32 {
+	let outer1:mut outer_struct = {[1, 2, 3, 4, 5], {1, 2.0}, 5};
+	let outer2:mut outer_struct = {[1, 2, 3, 4, 5], {5, 5.0d}, 5};
+	let outer3:mut outer_struct = {[1, 2, 3, 4, 5], {7, 7.0d}, 5};
+
+	let x:i32 = 6;
+	let y:i32 = 7;
+
+	/**
+	 * Copy all of the way over here with our nested struct. We should
+	 * hit the case where we end up using outer3
+	 */
+	let final_struct:inner_struct = (x > 5) ?
+										((y > 7) ? outer1:nested_inner else outer3:nested_inner)
+										 else outer2:nested_inner;
+
+	/**
+	 * Use the ternary struct assignment as the parameter 
+	 * Should return 7 * 3 = 21
+	 */
+	ret @my_fn(final_struct);
+}

--- a/oc/test_files/nested_struct_copy_let.ol
+++ b/oc/test_files/nested_struct_copy_let.ol
@@ -1,0 +1,41 @@
+/**
+* Author: Jack Robbins
+* Test the case where we are assigning(copying) a struct that is nested inside of another struct. This
+* specifically tests the case where we're copying on both the left and right hand sides so it is
+* most complex than usual
+*/
+
+define struct inner {
+	x:i32;
+	y:f64;
+} as inner_struct;
+
+
+define struct outer {
+	x:i32[5];
+	nested_inner:mut inner_struct;
+	holder:i32;
+} as outer_struct;
+
+
+//Pass by copy, returns 3 * x
+pub fn my_fn(param:inner_struct) -> i32 {
+	ret 3 * param:x;
+}
+
+
+pub fn main() -> i32 {
+	let outer1:mut outer_struct = {[1, 2, 3, 4, 5], {1, 2.0}, 5};
+	let outer2:mut outer_struct = {[1, 2, 3, 4, 5], {5, 5.0d}, 5};
+
+	let x:i32 = 6;
+
+	let final_struct:inner_struct = (x > 5) ? outer1:nested_inner
+										 else outer2:nested_inner;
+
+	/**
+	 * Use the ternary struct assignment as the parameter 
+	 * Should return 1 * 3 = 3
+	 */
+	ret @my_fn(final_struct);
+}


### PR DESCRIPTION
[Parser]: Enable memory copying from within ternary expressions

Add test coverage for these scenarios in let statements, assignments, and function parameters

Closes #899 