### PR TITLE
[Type System]: Ternary mutability with pointers

### DIFF
--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -9586,8 +9586,14 @@ static generic_ast_node_t* return_statement(ollie_token_stream_t* token_stream){
 
 	//If the current function's return type is not compatible with the return type here, we'll bail out
 	if(final_type == NULL){
-		sprintf(info, "Function \"%s\" expects a return type of \"%s\", but was given an incompatible type \"%s\"", current_function->func_name.string, current_function->return_type->type_name.string,
+		//Following that we'll generate another error message to make it more clear
+		sprintf(info, "Function \"%s\" expects a return type of \"%s%s\", but was given an incompatible type \"%s%s\"",
+		  		current_function->func_name.string,
+				(current_function->return_type->mutability == MUTABLE ? "mut " : ""),
+		  		current_function->return_type->type_name.string,
+		  		(expr_node->inferred_type->mutability == MUTABLE ? "mut " : ""),
 		  		expr_node->inferred_type->type_name.string);
+
 		print_parse_message(MESSAGE_TYPE_ERROR, info, parser_line_num);
 		//Also print out the function
 		print_function_name(current_function);

--- a/oc/compiler/type_system/type_system.c
+++ b/oc/compiler/type_system/type_system.c
@@ -1334,31 +1334,52 @@ generic_type_t* determine_compatibility_and_coerce(void* symtab, generic_type_t*
 				}
 			}
 			
-			//If b is a pointer type. This is teh exact same scenario as a
+			/**
+			 * For reference type assignability, the mutability level is very important
+			 * We need to be sure that we we are not setting something that is immutable
+			 * to a reference that is mutable or that would violate the entire structure
+			 * of the mutability. For this reason, if we're assigning pointers in a ternary,
+			 * we always take the lowest mutability level
+			 */
 			if((*b)->type_class == TYPE_CLASS_POINTER){
-				//If b is a another pointer, then that's fine
-				if((*a)->type_class == TYPE_CLASS_POINTER){
-					//We'll return a final comparison type of bool 
-					return lookup_type_name_only(symtab, "u64", (*a)->mutability)->type;
+				switch((*a)->type_class){
+					case TYPE_CLASS_POINTER:
+						//TODO NEEDS TO BE NO MUTABILITY
+						if(types_assignable(*b, *a) == NULL){
+							return NULL;
+						}
+
+						/**
+						 * If a is not mutable, then we just return that. If a
+						 * is mutable, then we return whatever b has in store
+						 * for us
+						 */
+						if((*b)->mutability == MUTABLE){
+							return *a;
+						} else {
+							return *b;
+						}
+
+					/**
+					 * For basic types it needs to be an integer. We return 
+					 * a's type
+					 */
+					case TYPE_CLASS_BASIC:
+						switch((*a)->basic_type_token){
+							case VOID:
+							case F32:
+							case F64:
+								return NULL;
+							default:
+								return *b;
+						}
+
+					/**
+					 * Something invalid here
+					 */
+					default:
+						return NULL;
 				}
-
-				//If this is not a basic type, all other conversion is bad
-				if((*a)->type_class != TYPE_CLASS_BASIC){
-					return NULL;
-				}
-
-				//Now once we get here, we know that we have a basic type
-
-				//Pointers are not compatible with floats in a comparison sense
-				if((*a)->basic_type_token == F32 || (*a)->basic_type_token == F64){
-					return NULL;
-				}
-
-				//If we get here, we know that B is valid for this. We will now expand it to be of type u64
-				*a = lookup_type_name_only(symtab, "u64", (*b)->mutability)->type;
-
-				//We'll return a final comparison type of bool 
-				return *a;
 			}
 
 			//At this point if these are not basic types, we're done

--- a/oc/compiler/type_system/type_system.c
+++ b/oc/compiler/type_system/type_system.c
@@ -776,6 +776,60 @@ generic_type_t* types_assignable(generic_type_t* destination_type, generic_type_
 
 
 /**
+ * Are two pointer types compatible? We use the same logic as types assignable does except we completely ignore the mutability
+ */
+static inline generic_type_t* pointer_types_compatible_ignore_mutability(generic_type_t* pointer_a, generic_type_t* pointer_b){
+	//If a is a void pointer then just give back whatever b is
+	if(pointer_a->internal_values.is_void_pointer == TRUE){
+		return pointer_b;
+	}
+
+	//If b is a void pointer then just give back whatever a is
+	if(pointer_b->internal_values.is_void_pointer == TRUE){
+		return pointer_b;
+	}
+
+
+	/**
+	 * If the memory layout type of the source and destination are different, then we cannot
+	 * assign them to eachother because if we were eventually to go and do memory access
+	 * using the [] operator, we would produce entirely different assembly code. Using
+	 * non-contiguous access on a contiguous region is almost certain to cause segfaults
+	 */
+	if(pointer_a->memory_layout_type != pointer_b->memory_layout_type){
+		return NULL;
+	}
+
+	/**
+	 * If we have pointers that have different underlying sizes, that is invalid. When we go to dereference the larger
+	 * pointer, we are now either reading into/corrupting other memory. For this reason, pointers must point to 
+	 * memory regions of the same physical size
+	 */
+	u_int32_t type_a_size_bytes = convert_type_size_to_bytes(get_type_size(pointer_a->internal_types.points_to));
+	u_int32_t type_b_size_bytes = convert_type_size_to_bytes(get_type_size(pointer_b->internal_types.points_to));
+
+	if(type_a_size_bytes != type_b_size_bytes){
+		return NULL;
+	}
+
+	//Now let's get what they both point tp
+	generic_type_t* type_a_points_to = pointer_a->internal_types.points_to; 
+	generic_type_t* type_b_points_to = pointer_b->internal_types.points_to; 
+
+	if(type_a_points_to->type_class == TYPE_CLASS_POINTER || type_b_points_to->type_class == TYPE_CLASS_POINTER){
+		return pointer_types_compatible_ignore_mutability(type_a_points_to, type_b_points_to);
+	} else {
+		//If this works, return the destination type
+		if(types_assignable(type_a_points_to, type_b_points_to) != NULL){
+			return pointer_a;
+		}
+	}
+
+	return NULL;
+}
+
+
+/**
  * Are two types *exactly* equal or not? This will account for type aliasing as well
  */
 u_int8_t types_identical(generic_type_t* a, generic_type_t* b){
@@ -1296,8 +1350,7 @@ generic_type_t* determine_compatibility_and_coerce(void* symtab, generic_type_t*
 			if((*a)->type_class == TYPE_CLASS_POINTER){
 				switch((*b)->type_class){
 					case TYPE_CLASS_POINTER:
-						//TODO NEEDS TO BE NO MUTABILITY
-						if(types_assignable(*a, *b) == NULL){
+						if(pointer_types_compatible_ignore_mutability(*a, *b) == NULL){
 							return NULL;
 						}
 
@@ -1344,8 +1397,7 @@ generic_type_t* determine_compatibility_and_coerce(void* symtab, generic_type_t*
 			if((*b)->type_class == TYPE_CLASS_POINTER){
 				switch((*a)->type_class){
 					case TYPE_CLASS_POINTER:
-						//TODO NEEDS TO BE NO MUTABILITY
-						if(types_assignable(*b, *a) == NULL){
+						if(pointer_types_compatible_ignore_mutability(*b, *a) == NULL){
 							return NULL;
 						}
 

--- a/oc/compiler/type_system/type_system.c
+++ b/oc/compiler/type_system/type_system.c
@@ -1286,9 +1286,28 @@ generic_type_t* determine_compatibility_and_coerce(void* symtab, generic_type_t*
 				}
 			}
 
-			//If a is a pointer type
+			/**
+			 * For reference type assignability, the mutability level is very important
+			 * We need to be sure that we we are not setting something that is immutable
+			 * to a reference that is mutable or that would violate the entire structure
+			 * of the mutability. For this reason, if we're assigning pointers in a ternary,
+			 * we always take the lowest mutability level
+			 */
 			if((*a)->type_class == TYPE_CLASS_POINTER){
-				//If b is a another pointer, then that's fine
+				switch((*b)->type_class){
+					case TYPE_CLASS_POINTER:
+
+					case TYPE_CLASS_BASIC:
+
+					/**
+					 * Something invalid here
+					 */
+					default:
+						return NULL;
+				}
+
+
+
 				if((*b)->type_class == TYPE_CLASS_POINTER){
 					//We'll return a final comparison type of u64
 					return lookup_type_name_only(symtab, "u64", (*a)->mutability)->type;

--- a/oc/compiler/type_system/type_system.c
+++ b/oc/compiler/type_system/type_system.c
@@ -1296,8 +1296,35 @@ generic_type_t* determine_compatibility_and_coerce(void* symtab, generic_type_t*
 			if((*a)->type_class == TYPE_CLASS_POINTER){
 				switch((*b)->type_class){
 					case TYPE_CLASS_POINTER:
+						//TODO NEEDS TO BE NO MUTABILITY
+						if(types_assignable(*a, *b) == NULL){
+							return NULL;
+						}
 
+						/**
+						 * If a is not mutable, then we just return that. If a
+						 * is mutable, then we return whatever b has in store
+						 * for us
+						 */
+						if((*a)->mutability == MUTABLE){
+							return *b;
+						} else {
+							return *a;
+						}
+
+					/**
+					 * For basic types it needs to be an integer. We return 
+					 * a's type
+					 */
 					case TYPE_CLASS_BASIC:
+						switch((*b)->basic_type_token){
+							case VOID:
+							case F32:
+							case F64:
+								return NULL;
+							default:
+								return *a;
+						}
 
 					/**
 					 * Something invalid here
@@ -1305,30 +1332,6 @@ generic_type_t* determine_compatibility_and_coerce(void* symtab, generic_type_t*
 					default:
 						return NULL;
 				}
-
-
-
-				if((*b)->type_class == TYPE_CLASS_POINTER){
-					//We'll return a final comparison type of u64
-					return lookup_type_name_only(symtab, "u64", (*a)->mutability)->type;
-				}
-
-				//If this is not a basic type, all other conversion is bad
-				if((*b)->type_class != TYPE_CLASS_BASIC){
-					return NULL;
-				}
-
-				//Now once we get here, we know that we have a basic type
-
-				//Pointers are not compatible with floats in a comparison sense
-				if((*b)->basic_type_token == F32 || (*b)->basic_type_token == F64){
-					return NULL;
-				}
-
-				//If we get here, we know that B is valid for this. We will now expand it to be of type u64
-				*b = lookup_type_name_only(symtab, "u64", (*a)->mutability)->type;
-
-				return *b;
 			}
 			
 			//If b is a pointer type. This is teh exact same scenario as a

--- a/oc/test_files/invalid_ternary_assign_immut_to_mut_ptr.ol
+++ b/oc/test_files/invalid_ternary_assign_immut_to_mut_ptr.ol
@@ -1,0 +1,19 @@
+/**
+* Author: Jack Robbins
+* Test an invalid case for a ternary that leads to us trying to assign from immutable to mutable
+*/
+
+
+pub fn ternary_assign(decider:i32, x:i32*, y:mut i32*) -> mut i32* {
+	/**
+	* Should fail - the type system should decide that the ternary
+	* is not mutable and since the return type is, we're trying
+	* to assign mutable to immutable
+	*/
+	ret (decider > 3) ? x else y;
+}
+
+
+pub fn main() -> i32 {
+	ret 0;
+}

--- a/oc/test_files/ternary_assign_pointer_valid.ol
+++ b/oc/test_files/ternary_assign_pointer_valid.ol
@@ -1,0 +1,24 @@
+/**
+* Author: Jack Robbins
+* Test a valid case where we perform pointer assignment on a ternary
+*/
+
+
+pub fn ternary_assign(decider:i32, x:i32*, y:mut i32*) -> i32* {
+	/**
+	 * Should work since we have an immut pointer return type
+	 */
+	ret (decider > 3) ? x else y;
+}
+
+
+pub fn main() -> i32 {
+	let x:mut i32 = 5;
+	let y:mut i32 = 3;
+
+	let x_ptr:mut i32* = &x;
+	let y_ptr:mut i32* = &y;
+
+	//OUNIT: [console = 5]
+	ret *(@ternary_assign(4, x_ptr, y_ptr));
+}


### PR DESCRIPTION
[Type System]: Ternary mutability with pointers - ternary mutability with pointers now works correctly. If we have pointers
on either side of the ternary, we will always take the lowest mutability level of them both.

Closes #907 