### PR TITLE
[Front End]: Ollie in statements with a contiguous range are automatically converted to an efficient conditional move chain

### DIFF
--- a/oc/compiler/ast/ast.h
+++ b/oc/compiler/ast/ast.h
@@ -169,8 +169,16 @@ struct generic_ast_node_t{
 	u_int8_t dereference_needed;
 	//Is the given statement(switch or in) eligible to internally be a true switch?
 	u_int8_t is_switch_eligible;
-	//Is the given switch/in statement "exhaustive" - this is most usually false
-	u_int8_t is_exhaustive;
+	/**
+	 * This union has two values:
+	 *
+	 * 1.) Is the given switch statement "exhaustive" - this is most usually false
+	 * 2.) Is the given in statement "contiguous" - no gaps between values
+	 */
+	union {
+		u_int8_t is_exhaustive_switch;
+		u_int8_t is_contiguous_in;
+	} struct_in_values;
 };
 
 /**

--- a/oc/compiler/ast/ast.h
+++ b/oc/compiler/ast/ast.h
@@ -178,7 +178,7 @@ struct generic_ast_node_t{
 	union {
 		u_int8_t is_exhaustive_switch;
 		u_int8_t is_contiguous_in;
-	} struct_in_values;
+	} switch_in_values;
 };
 
 /**

--- a/oc/compiler/ast/ast.h
+++ b/oc/compiler/ast/ast.h
@@ -169,8 +169,8 @@ struct generic_ast_node_t{
 	u_int8_t dereference_needed;
 	//Is the given statement(switch or in) eligible to internally be a true switch?
 	u_int8_t is_switch_eligible;
-	//Is the given switch "exhaustive" - this is most usually false
-	u_int8_t is_exhaustive_switch;
+	//Is the given switch/in statement "exhaustive" - this is most usually false
+	u_int8_t is_exhaustive;
 };
 
 /**

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -10045,7 +10045,7 @@ static inline cfg_result_package_t visit_c_style_switch_statement(generic_ast_no
 	 * for non-exhaustive switches. If it is exhaustive, we'll route it to
 	 * the simpler exhaustive switch converter
 	 */
-	if(root_node->struct_in_values.is_exhaustive_switch == FALSE){
+	if(root_node->switch_in_values.is_exhaustive_switch == FALSE){
 		return visit_non_exhaustive_c_style_switch_statement(root_node);
 	} else {
 		return visit_exhaustive_c_style_switch_statement(root_node);
@@ -10596,7 +10596,7 @@ static inline cfg_result_package_t visit_switch_statement(generic_ast_node_t* ro
 	 * switch will not have that. These types of switches are different enough
 	 * to warrant separate methods
 	 */
-	if(root_node->struct_in_values.is_exhaustive_switch == FALSE){
+	if(root_node->switch_in_values.is_exhaustive_switch == FALSE){
 		return visit_non_exhaustive_ollie_switch_statement(root_node);
 	} else {
 		return visit_exhaustive_ollie_switch_statement(root_node);

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -5805,16 +5805,52 @@ static inline cfg_result_package_t lower_in_expression_to_oir_switch(basic_block
  * 	final_result = result
  *
  * Notice how the jump table is really useless because they all have the same targets. Instead of this, we can do the following:
- * movl true, result
  * cmpl $1, x
- * cmovl false, result
+ * result1 <- cmov_l false else true
  * cmpl $5, x
- * cmovg false, result
+ * result2 <- cmov_g false else result1
+ * final_result = result2
  *
  * This achieves the same output with a much smaller final instruction footprint and a much smaller OIR footprint, which makes both
  * compilation and eventual runtime faster
  */
 static inline cfg_result_package_t lower_contiguous_in_expression_to_oir_conditional_move_chain(basic_block_t* starting_block, generic_ast_node_t* in_node){
+	//We can initialize these results off the bat
+	cfg_result_package_t results = INITIALIZE_BLANK_CFG_RESULT;
+	results.starting_block = starting_block;
+
+	//We'll need to keep track of the current block in case of expression changes
+	basic_block_t* current_block = starting_block;
+
+	//Extract the highest and lowest values for convenience
+	int32_t min_value = in_node->optional_storage.switch_bounds.lower_bound;
+	int32_t max_value = in_node->optional_storage.switch_bounds.upper_bound;
+
+	/**
+	 * The first child is always the starting expression. We will emit that first
+	 */
+	generic_ast_node_t* cursor = in_node->first_child;
+	cfg_result_package_t expression_results = emit_expression(starting_block, cursor);
+
+	//Update the current block and unpack the results
+	current_block = expression_results.final_block;
+	three_addr_var_t* comparing_to_var = unpack_result_package(&expression_results, current_block);
+
+	/**
+	 * Step 2: Emit the true and false constants that we'll need for later on. 
+	 * Since OIR conditional moves do not have a place for two constants, we will
+	 * have to emit a temporary variable assignment for the true and false constants
+	 */
+	three_addr_const_t* true_constant = emit_direct_integer_or_char_constant(TRUE, i8);
+	three_addr_const_t* false_constant = emit_direct_integer_or_char_constant(FALSE, i8);
+	three_addr_var_t* false_variable = emit_temp_var(i8);
+
+	instruction_t* false_assignment = emit_assignment_with_const_instruction(false_variable, false_constant);
+	add_statement(current_block, false_assignment);
+
+
+
+
 	printf("TODO NOT IMPLEMENTED\n");
 	exit(1);
 }

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -5874,12 +5874,41 @@ static inline cfg_result_package_t lower_contiguous_in_expression_to_oir_conditi
 																						 	first_move_type);
 	add_statement(current_block, first_conditional_move);
 
+	/**
+	 * Step 4: Emit the greater than comparison. If we are higher than the highest value, we will move
+	 * in a false constant. Otherwise, we move in true
+	 */
+	three_addr_const_t* max_value_constant = emit_direct_integer_or_char_constant(max_value, i32);
 
+	//Emit and add the greater than comparison
+	instruction_t* second_comparison = emit_binary_operation_with_const_instruction(emit_temp_var(i8), comparing_to_var, G_THAN, max_value_constant);
+	add_statement(current_block, first_comparison);
 
+	//Determine the appropriate type based on operand signenedness
+	conditional_movement_type_t second_move_type = is_type_signed(operand_type) == TRUE ? MOVE_G : MOVE_A;
 
+	//Now we can emit and add the first conditional variable
+	three_addr_var_t* result_var_2 = emit_temp_var(i8);
+	instruction_t* second_conditional_move =  emit_conditional_movement_with_const_statement(result_var_1,
+																						 	 false_variable,
+																						 	 true_constant,
+																						 	 second_comparison->operands.oir.assignee,
+																						 	 second_move_type);
+	add_statement(current_block, second_conditional_move);
 
-	printf("TODO NOT IMPLEMENTED\n");
-	exit(1);
+	/**
+	 * Step 5: emit one final assignment from the final result
+	 * var into a final temporary variable of our given type
+	 */
+	three_addr_var_t* final_variable = emit_temp_var(in_node->inferred_type);
+	instruction_t* final_assignment = emit_assignment_instruction(final_variable, result_var_2);
+	add_statement(current_block, final_assignment);
+
+	//Package up and give back our results
+	results.type = CFG_RESULT_TYPE_VAR;
+	results.result_value.result_var = final_variable;
+	results.final_block = current_block;
+	return results;
 }
 
 

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -5827,7 +5827,8 @@ static inline cfg_result_package_t lower_contiguous_in_expression_to_oir_conditi
 	int32_t max_value = in_node->optional_storage.switch_bounds.upper_bound;
 
 	/**
-	 * The first child is always the starting expression. We will emit that first
+	 * Step 1: The first child is always the starting expression. We will emit that first
+	 * and then unpack it to have on hand for our comparisons
 	 */
 	generic_ast_node_t* cursor = in_node->first_child;
 	cfg_result_package_t expression_results = emit_expression(starting_block, cursor);
@@ -5835,6 +5836,9 @@ static inline cfg_result_package_t lower_contiguous_in_expression_to_oir_conditi
 	//Update the current block and unpack the results
 	current_block = expression_results.final_block;
 	three_addr_var_t* comparing_to_var = unpack_result_package(&expression_results, current_block);
+
+	//Store the operand type - this will determine what we use for signed/unsigned comparison
+	generic_type_t* operand_type = get_operand_type_for_relational_operation(type_symtab, comparing_to_var->type, i32);
 
 	/**
 	 * Step 2: Emit the true and false constants that we'll need for later on. 
@@ -5847,6 +5851,29 @@ static inline cfg_result_package_t lower_contiguous_in_expression_to_oir_conditi
 
 	instruction_t* false_assignment = emit_assignment_with_const_instruction(false_variable, false_constant);
 	add_statement(current_block, false_assignment);
+
+	/**
+	 * Step 3: Emit the lower than comparison. If we are lower than the lowest value, we will move
+	 * in a false constant. Otherwise, we move in true
+	 */
+	three_addr_const_t* min_value_constant = emit_direct_integer_or_char_constant(min_value, i32);
+
+	//Emit and add the lower than comparison
+	instruction_t* first_comparison = emit_binary_operation_with_const_instruction(emit_temp_var(i8), comparing_to_var, L_THAN, min_value_constant);
+	add_statement(current_block, first_comparison);
+
+	//Determine the appropriate type based on operand signenedness
+	conditional_movement_type_t first_move_type = is_type_signed(operand_type) == TRUE ? MOVE_L : MOVE_B;
+
+	//Now we can emit and add the first conditional variable
+	three_addr_var_t* result_var_1 = emit_temp_var(i8);
+	instruction_t* first_conditional_move =  emit_conditional_movement_with_const_statement(result_var_1,
+																						 	false_variable,
+																						 	true_constant,
+																						 	first_comparison->operands.oir.assignee,
+																						 	first_move_type);
+	add_statement(current_block, first_conditional_move);
+
 
 
 

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -5770,6 +5770,50 @@ static inline cfg_result_package_t lower_in_expression_to_oir_switch(basic_block
 }
 
 
+/**
+ * For in expressions that are contiguous - that is, they're values are all separated by 1 each - we can skip the switch statement
+ * and go right to a conditional move chain.
+ *
+ * Example: x in (1, 2, 3, 4, 5)
+ *
+ * If we were to use a switch statement, this would become:
+ *
+ * 	cmpl $1, x
+ * 	jl default
+ * 	cmpl $5, x
+ * 	jg default
+ *
+ * 	.JT1:
+ * 	  .L5
+ * 	  .L5
+ * 	  .L5
+ * 	  .L5
+ * 	  .L5
+ *
+ * 	temp = x - 1
+ * 	jmp *.JT1(, x, 8)
+ *
+ * 	.L5:
+ * 	  movl true, result
+ * 	  jmp end
+ *
+ * 	 default:
+ * 	  movl false, result
+ * 	  jmp end
+ *
+ * end:
+ * 	final_result = result
+ *
+ * Notice how the jump table is really useless because they all have the same targets. Instead of this, we can do the following:
+ * movl true, result
+ * cmpl $1, x
+ * cmovl false, result
+ * cmpl $5, x
+ * cmovg false, result
+ *
+ * This achieves the same output with a much smaller final instruction footprint and a much smaller OIR footprint, which makes both
+ * compilation and eventual runtime faster
+ */
 static inline cfg_result_package_t lower_contiguous_in_expression_to_oir_conditional_move_chain(basic_block_t* starting_block, generic_ast_node_t* in_node){
 	printf("TODO NOT IMPLEMENTED\n");
 	exit(1);

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -5876,24 +5876,24 @@ static inline cfg_result_package_t lower_contiguous_in_expression_to_oir_conditi
 
 	/**
 	 * Step 4: Emit the greater than comparison. If we are higher than the highest value, we will move
-	 * in a false constant. Otherwise, we move in true
+	 * in a false constant. Otherwise, we defer to whatever the old value was
 	 */
 	three_addr_const_t* max_value_constant = emit_direct_integer_or_char_constant(max_value, i32);
 
 	//Emit and add the greater than comparison
 	instruction_t* second_comparison = emit_binary_operation_with_const_instruction(emit_temp_var(i8), comparing_to_var, G_THAN, max_value_constant);
-	add_statement(current_block, first_comparison);
+	add_statement(current_block, second_comparison);
 
 	//Determine the appropriate type based on operand signenedness
 	conditional_movement_type_t second_move_type = is_type_signed(operand_type) == TRUE ? MOVE_G : MOVE_A;
 
-	//Now we can emit and add the first conditional variable
+	//Now we can emit and add the second conditional variable
 	three_addr_var_t* result_var_2 = emit_temp_var(i8);
-	instruction_t* second_conditional_move =  emit_conditional_movement_with_const_statement(result_var_1,
-																						 	 false_variable,
-																						 	 true_constant,
-																						 	 second_comparison->operands.oir.assignee,
-																						 	 second_move_type);
+	instruction_t* second_conditional_move =  emit_conditional_movement_statement(result_var_2,
+																				  false_variable,
+																				  result_var_1,
+																				  second_comparison->operands.oir.assignee,
+																				  second_move_type);
 	add_statement(current_block, second_conditional_move);
 
 	/**

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -10045,7 +10045,7 @@ static inline cfg_result_package_t visit_c_style_switch_statement(generic_ast_no
 	 * for non-exhaustive switches. If it is exhaustive, we'll route it to
 	 * the simpler exhaustive switch converter
 	 */
-	if(root_node->is_exhaustive == FALSE){
+	if(root_node->struct_in_values.is_exhaustive_switch == FALSE){
 		return visit_non_exhaustive_c_style_switch_statement(root_node);
 	} else {
 		return visit_exhaustive_c_style_switch_statement(root_node);
@@ -10596,7 +10596,7 @@ static inline cfg_result_package_t visit_switch_statement(generic_ast_node_t* ro
 	 * switch will not have that. These types of switches are different enough
 	 * to warrant separate methods
 	 */
-	if(root_node->is_exhaustive == FALSE){
+	if(root_node->struct_in_values.is_exhaustive_switch == FALSE){
 		return visit_non_exhaustive_ollie_switch_statement(root_node);
 	} else {
 		return visit_exhaustive_ollie_switch_statement(root_node);

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -10045,7 +10045,7 @@ static inline cfg_result_package_t visit_c_style_switch_statement(generic_ast_no
 	 * for non-exhaustive switches. If it is exhaustive, we'll route it to
 	 * the simpler exhaustive switch converter
 	 */
-	if(root_node->is_exhaustive_switch == FALSE){
+	if(root_node->is_exhaustive == FALSE){
 		return visit_non_exhaustive_c_style_switch_statement(root_node);
 	} else {
 		return visit_exhaustive_c_style_switch_statement(root_node);
@@ -10596,7 +10596,7 @@ static inline cfg_result_package_t visit_switch_statement(generic_ast_node_t* ro
 	 * switch will not have that. These types of switches are different enough
 	 * to warrant separate methods
 	 */
-	if(root_node->is_exhaustive_switch == FALSE){
+	if(root_node->is_exhaustive == FALSE){
 		return visit_non_exhaustive_ollie_switch_statement(root_node);
 	} else {
 		return visit_exhaustive_ollie_switch_statement(root_node);

--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -5770,6 +5770,12 @@ static inline cfg_result_package_t lower_in_expression_to_oir_switch(basic_block
 }
 
 
+static inline cfg_result_package_t lower_contiguous_in_expression_to_oir_conditional_move_chain(basic_block_t* starting_block, generic_ast_node_t* in_node){
+	printf("TODO NOT IMPLEMENTED\n");
+	exit(1);
+}
+
+
 /**
  * Lower the entire in expression into an OIR if-else-if chain using regular branching. This if-else-if chain is done so that we 
  * automatically have a short circuit by the time this is implemented. 
@@ -5988,7 +5994,16 @@ static inline cfg_result_package_t lower_in_expression_to_conditional_move_chain
  */
 static cfg_result_package_t emit_in_expression(basic_block_t* starting_block, generic_ast_node_t* in_expression){
 	if(in_expression->is_switch_eligible == TRUE){
-		return lower_in_expression_to_oir_switch(starting_block, in_expression);
+		/**
+		 * If we have a "contiguous in", there is an optimization that we can
+		 * do to remove the need for a switch entirely. This is a case that is
+		 * common enough to consider a specialized optimization
+		 */
+		if(in_expression->switch_in_values.is_contiguous_in == FALSE){
+			return lower_in_expression_to_oir_switch(starting_block, in_expression);
+		} else {
+			return lower_contiguous_in_expression_to_oir_conditional_move_chain(starting_block, in_expression);
+		}
 	} else {
 		return lower_in_expression_to_conditional_move_chain(starting_block, in_expression);
 	}

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -10488,13 +10488,13 @@ static generic_ast_node_t* switch_statement(ollie_token_stream_t* token_stream){
 
 	//Let the helpers determine the switch eligibility and exhaustive switch eligibility
 	switch_stmt_node->is_switch_eligible = determine_switch_eligibility(&switch_values);
-	switch_stmt_node->is_exhaustive = is_switch_exhaustive_switch(switching_on_type, &switch_values);
+	switch_stmt_node->struct_in_values.is_exhaustive_switch = is_switch_exhaustive_switch(switching_on_type, &switch_values);
 
 	/**
 	 * If this is not exhaustive and we have not found the default clause, then this is an error
 	 * and we fail out
 	 */
-	if(switch_stmt_node->is_exhaustive == FALSE && found_default_clause == FALSE){
+	if(switch_stmt_node->struct_in_values.is_exhaustive_switch == FALSE && found_default_clause == FALSE){
 		return print_and_return_error("Non-exhaustive switch statements are required to have a \"default\" clause", parser_line_num);
 	}
 
@@ -10502,7 +10502,7 @@ static generic_ast_node_t* switch_statement(ollie_token_stream_t* token_stream){
 	 * If this is exhaustive and we do have a default clause, then that default clause is actually unreachable. We will fail
 	 * out if we detect that this is the case
 	 */
-	if(switch_stmt_node->is_exhaustive == TRUE && found_default_clause == TRUE){
+	if(switch_stmt_node->struct_in_values.is_exhaustive_switch == TRUE && found_default_clause == TRUE){
 		return print_and_return_error("Default clause is unreachable in exhaustive switch statement", parser_line_num);
 	}
 

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -6347,6 +6347,20 @@ static inline u_int8_t determine_in_statement_switch_eligibility(generic_ast_nod
 		return FALSE;
 	}
 
+	/**
+	 * If the average distance is 1, then we have what we call a contiguous in
+	 * statement where all of the integer values are 1 apart. This lends itself
+	 * to a natural optimization where instead of using a jump table, we can just use
+	 * two jump statements to determine if our value is within the given contiguous
+	 * range. We will set the flag here if this is the case
+	 *
+	 * TODO WILL THIS WORK???
+	 */
+	if(average_distance == 1){
+		in_statement_node->switch_in_values.is_contiguous_in = TRUE;
+		printf("HERE\n\n\n\n\n");
+	}
+
 	//If we've made it here, we can populate the bounds and return success
 	in_statement_node->optional_storage.switch_bounds.lower_bound = sorted_in_member_values->internal_array[0];
 	in_statement_node->optional_storage.switch_bounds.upper_bound = sorted_in_member_values->internal_array[sorted_in_member_values->current_index - 1];
@@ -10488,13 +10502,13 @@ static generic_ast_node_t* switch_statement(ollie_token_stream_t* token_stream){
 
 	//Let the helpers determine the switch eligibility and exhaustive switch eligibility
 	switch_stmt_node->is_switch_eligible = determine_switch_eligibility(&switch_values);
-	switch_stmt_node->struct_in_values.is_exhaustive_switch = is_switch_exhaustive_switch(switching_on_type, &switch_values);
+	switch_stmt_node->switch_in_values.is_exhaustive_switch = is_switch_exhaustive_switch(switching_on_type, &switch_values);
 
 	/**
 	 * If this is not exhaustive and we have not found the default clause, then this is an error
 	 * and we fail out
 	 */
-	if(switch_stmt_node->struct_in_values.is_exhaustive_switch == FALSE && found_default_clause == FALSE){
+	if(switch_stmt_node->switch_in_values.is_exhaustive_switch == FALSE && found_default_clause == FALSE){
 		return print_and_return_error("Non-exhaustive switch statements are required to have a \"default\" clause", parser_line_num);
 	}
 
@@ -10502,7 +10516,7 @@ static generic_ast_node_t* switch_statement(ollie_token_stream_t* token_stream){
 	 * If this is exhaustive and we do have a default clause, then that default clause is actually unreachable. We will fail
 	 * out if we detect that this is the case
 	 */
-	if(switch_stmt_node->struct_in_values.is_exhaustive_switch == TRUE && found_default_clause == TRUE){
+	if(switch_stmt_node->switch_in_values.is_exhaustive_switch == TRUE && found_default_clause == TRUE){
 		return print_and_return_error("Default clause is unreachable in exhaustive switch statement", parser_line_num);
 	}
 

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -10202,25 +10202,23 @@ static inline u_int8_t is_switch_exhaustive_switch(generic_type_t* switching_on_
 	}
 
 	/**
-	 * Check 2: if the average distance between values does not exactly equal
-	 * 1, then the switch is not exhaustive. If it does equal 1, then it is
-	 * exhaustive because we already know that the upper and lower bounds exactly
-	 * match the enum upper and lower bounds
+	 * Check 2: if the distance between each consecutive value is always 1, then
+	 * the switch must be exhaustive because the min and max values match the
+	 * enum min and max *and* we always have the correct distance. If there
+	 * is at least one instance where it is not one, we fail out
 	 */
-	int64_t average_distance = 0;
 	for(int32_t i = 1; i < switch_statement_values->current_index; i++){
 		int32_t first_value = switch_statement_values->internal_array[i - 1];
 		int32_t second_value = switch_statement_values->internal_array[i];
 
-		average_distance += (second_value - first_value);
+		//Only takes one instance to fail
+		if(second_value - first_value != 1){
+			return FALSE;
+		}
 	}
 
-	//Compute the average distance by dividing by the number of distances(n-1 for n numbers)
-	average_distance /= (switch_statement_values->current_index - 1);
-
-	printf("AVERAGE DISTANCE IS %ld\n", average_distance);
-
-	return average_distance != 1 ? FALSE : TRUE;
+	//If we made it to here then we're good
+	return TRUE;
 }
 
 

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -8024,6 +8024,9 @@ static u_int8_t enum_definer(ollie_token_stream_t* token_stream){
 			num_errors++;
 			return FAILURE;
 		}
+		
+		//Add the enum member value into the sorted array for later
+		sorted_dynamic_integer_array_insert_unique(&sorted_integer_values, member_record->enum_member_value);
 
 		//This goes up by 1
 		current_enum_value++;
@@ -8060,6 +8063,28 @@ static u_int8_t enum_definer(ollie_token_stream_t* token_stream){
 	immutable_enum_type->internal_values.enum_integer_type = type_needed;
 	//Assign the size over as well
 	immutable_enum_type->type_size = type_needed->type_size;
+
+	/**
+	 * If we have an enum type that, when all members are sorted, each value
+	 * is 1 apart, we refer to that internally as a "contiguous enum". We will set
+	 * a flag in the type for this. This is important for exhaustive switch/contiguous
+	 * in determination later on
+	 */
+	u_int8_t is_contiguous = TRUE;
+	for(int32_t i = 1; i < sorted_integer_values.current_index; i++){
+		int32_t first_value = sorted_integer_values.internal_array[i - 1];
+		int32_t second_value = sorted_integer_values.internal_array[i];
+
+		//Only takes 1 for this to fail out
+		if(second_value - first_value != 1){
+			is_contiguous = FALSE;
+			break;
+		}
+	}
+
+	//Set both types to this
+	mutable_enum_type->is_contiguous_enum = is_contiguous;
+	immutable_enum_type->is_contiguous_enum = is_contiguous;
 
 	//Now once we are here, we can optionally see an alias command. These alias commands are helpful and convenient
 	//for redefining variables immediately upon declaration. They are prefaced by the "As" keyword

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -10488,13 +10488,13 @@ static generic_ast_node_t* switch_statement(ollie_token_stream_t* token_stream){
 
 	//Let the helpers determine the switch eligibility and exhaustive switch eligibility
 	switch_stmt_node->is_switch_eligible = determine_switch_eligibility(&switch_values);
-	switch_stmt_node->is_exhaustive_switch = is_switch_exhaustive_switch(switching_on_type, &switch_values);
+	switch_stmt_node->is_exhaustive = is_switch_exhaustive_switch(switching_on_type, &switch_values);
 
 	/**
 	 * If this is not exhaustive and we have not found the default clause, then this is an error
 	 * and we fail out
 	 */
-	if(switch_stmt_node->is_exhaustive_switch == FALSE && found_default_clause == FALSE){
+	if(switch_stmt_node->is_exhaustive == FALSE && found_default_clause == FALSE){
 		return print_and_return_error("Non-exhaustive switch statements are required to have a \"default\" clause", parser_line_num);
 	}
 
@@ -10502,7 +10502,7 @@ static generic_ast_node_t* switch_statement(ollie_token_stream_t* token_stream){
 	 * If this is exhaustive and we do have a default clause, then that default clause is actually unreachable. We will fail
 	 * out if we detect that this is the case
 	 */
-	if(switch_stmt_node->is_exhaustive_switch == TRUE && found_default_clause == TRUE){
+	if(switch_stmt_node->is_exhaustive == TRUE && found_default_clause == TRUE){
 		return print_and_return_error("Default clause is unreachable in exhaustive switch statement", parser_line_num);
 	}
 

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -6307,9 +6307,13 @@ static inline u_int8_t is_constant_valid_for_in_statement_type(generic_type_t* i
  * to handle this
  *
  * This rule will also leverage the traversal of the in members that it is already
- * doing to determine a min and max value
+ * doing to determine a min and max value, and to determine if the in statement
+ * is a contiguous in statement(this is needed for optimizations down the road)
  */
 static inline u_int8_t determine_in_statement_switch_eligibility(generic_ast_node_t* in_statement_node, dynamic_integer_array_t* sorted_in_member_values){
+	//By default assume we are contiguosu
+	u_int8_t is_contiguous = TRUE;
+
 	/**
 	 * If the user has done something silly like an in-statement with only one member, we will rewrite this for them
 	 */
@@ -6336,6 +6340,11 @@ static inline u_int8_t determine_in_statement_switch_eligibility(generic_ast_nod
 		int32_t first_value = sorted_in_member_values->internal_array[i - 1];
 		int32_t second_value = sorted_in_member_values->internal_array[i];
 
+		//Only takes one case for this to not work
+		if(second_value - first_value != 1){
+			is_contiguous = FALSE;
+		}
+
 		average_distance += (second_value - first_value);
 	}
 
@@ -6346,18 +6355,14 @@ static inline u_int8_t determine_in_statement_switch_eligibility(generic_ast_nod
 	if(average_distance > MAX_AVERAGE_CASE_DIFFERENCE){
 		return FALSE;
 	}
-	
-	/**
-	 * If the average distance is 1, then we have what we call a contiguous in
-	 * statement where all of the integer values are 1 apart. This lends itself
-	 * to a natural optimization where instead of using a jump table, we can just use
-	 * two jump statements to determine if our value is within the given contiguous
-	 * range. We will set the flag here if this is the case
-	 */
-	if(average_distance == 1){
-		in_statement_node->switch_in_values.is_contiguous_in = TRUE;
-	}
 
+	//Set this flag for it being contiguous as well
+	in_statement_node->switch_in_values.is_contiguous_in = is_contiguous;
+
+	if(is_contiguous == TRUE){
+		printf("ITS CONTIGUOUS\n\n\n");
+	}
+	
 	//If we've made it here, we can populate the bounds and return success
 	in_statement_node->optional_storage.switch_bounds.lower_bound = sorted_in_member_values->internal_array[0];
 	in_statement_node->optional_storage.switch_bounds.upper_bound = sorted_in_member_values->internal_array[sorted_in_member_values->current_index - 1];

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -6358,10 +6358,6 @@ static inline u_int8_t determine_in_statement_switch_eligibility(generic_ast_nod
 
 	//Set this flag for it being contiguous as well
 	in_statement_node->switch_in_values.is_contiguous_in = is_contiguous;
-
-	if(is_contiguous == TRUE){
-		printf("ITS CONTIGUOUS\n\n\n");
-	}
 	
 	//If we've made it here, we can populate the bounds and return success
 	in_statement_node->optional_storage.switch_bounds.lower_bound = sorted_in_member_values->internal_array[0];

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -6330,13 +6330,29 @@ static inline u_int8_t determine_in_statement_switch_eligibility(generic_ast_nod
 	 * important because we only care about the average distance between
 	 * values that are adjacent numerically. It doesn't matter if they're
 	 * out of order
+	 *
+	 * If the distance is always 1, then we have what we call a contiguous in
+	 * statement where all of the integer values are 1 apart. This lends itself
+	 * to a natural optimization where instead of using a jump table, we can just use
+	 * two jump statements to determine if our value is within the given contiguous
+	 * range. We will set the flag here if this is the case
 	 */
 	int64_t average_distance = 0;
+	u_int8_t is_contiguous_in = TRUE;
 	for(int32_t i = 1; i < sorted_in_member_values->current_index; i++){
 		int32_t first_value = sorted_in_member_values->internal_array[i - 1];
 		int32_t second_value = sorted_in_member_values->internal_array[i];
 
-		average_distance += (second_value - first_value);
+		int32_t distance = second_value - first_value;
+		average_distance += distance;
+
+		/**
+		 * If we have one instance where this is 1, we are no longer eligible
+		 * to be considered as a contiguous in expression
+		 */
+		if(distance != 1){
+			is_contiguous_in = FALSE;
+		}
 	}
 
 	//Find the actual average
@@ -6347,23 +6363,13 @@ static inline u_int8_t determine_in_statement_switch_eligibility(generic_ast_nod
 		return FALSE;
 	}
 
-	/**
-	 * If the average distance is 1, then we have what we call a contiguous in
-	 * statement where all of the integer values are 1 apart. This lends itself
-	 * to a natural optimization where instead of using a jump table, we can just use
-	 * two jump statements to determine if our value is within the given contiguous
-	 * range. We will set the flag here if this is the case
-	 *
-	 * TODO WILL THIS WORK???
-	 */
-	if(average_distance == 1){
-		in_statement_node->switch_in_values.is_contiguous_in = TRUE;
-		printf("HERE\n\n\n\n\n");
-	}
-
 	//If we've made it here, we can populate the bounds and return success
 	in_statement_node->optional_storage.switch_bounds.lower_bound = sorted_in_member_values->internal_array[0];
 	in_statement_node->optional_storage.switch_bounds.upper_bound = sorted_in_member_values->internal_array[sorted_in_member_values->current_index - 1];
+
+	//Flag whether we are a contiguous in
+	in_statement_node->switch_in_values.is_contiguous_in = is_contiguous_in;
+
 	return TRUE;
 }
 

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -6330,46 +6330,37 @@ static inline u_int8_t determine_in_statement_switch_eligibility(generic_ast_nod
 	 * important because we only care about the average distance between
 	 * values that are adjacent numerically. It doesn't matter if they're
 	 * out of order
-	 *
-	 * If the distance is always 1, then we have what we call a contiguous in
-	 * statement where all of the integer values are 1 apart. This lends itself
-	 * to a natural optimization where instead of using a jump table, we can just use
-	 * two jump statements to determine if our value is within the given contiguous
-	 * range. We will set the flag here if this is the case
 	 */
 	int64_t average_distance = 0;
-	u_int8_t is_contiguous_in = TRUE;
 	for(int32_t i = 1; i < sorted_in_member_values->current_index; i++){
 		int32_t first_value = sorted_in_member_values->internal_array[i - 1];
 		int32_t second_value = sorted_in_member_values->internal_array[i];
 
-		int32_t distance = second_value - first_value;
-		average_distance += distance;
-
-		/**
-		 * If we have one instance where this is 1, we are no longer eligible
-		 * to be considered as a contiguous in expression
-		 */
-		if(distance != 1){
-			is_contiguous_in = FALSE;
-		}
+		average_distance += (second_value - first_value);
 	}
 
 	//Find the actual average
-	average_distance /= sorted_in_member_values->current_index;
+	average_distance /= (sorted_in_member_values->current_index - 1);
 
 	//If it exceeds the max distance it is not switch eligible(too sparse)
 	if(average_distance > MAX_AVERAGE_CASE_DIFFERENCE){
 		return FALSE;
 	}
+	
+	/**
+	 * If the average distance is 1, then we have what we call a contiguous in
+	 * statement where all of the integer values are 1 apart. This lends itself
+	 * to a natural optimization where instead of using a jump table, we can just use
+	 * two jump statements to determine if our value is within the given contiguous
+	 * range. We will set the flag here if this is the case
+	 */
+	if(average_distance == 1){
+		in_statement_node->switch_in_values.is_contiguous_in = TRUE;
+	}
 
 	//If we've made it here, we can populate the bounds and return success
 	in_statement_node->optional_storage.switch_bounds.lower_bound = sorted_in_member_values->internal_array[0];
 	in_statement_node->optional_storage.switch_bounds.upper_bound = sorted_in_member_values->internal_array[sorted_in_member_values->current_index - 1];
-
-	//Flag whether we are a contiguous in
-	in_statement_node->switch_in_values.is_contiguous_in = is_contiguous_in;
-
 	return TRUE;
 }
 
@@ -10093,7 +10084,7 @@ static inline u_int8_t determine_switch_eligibility(dynamic_integer_array_t* swi
 	}
 
 	//Now get the actual average distance
-	average_distance /= switch_statement_values->current_index;
+	average_distance /= (switch_statement_values->current_index - 1);
 
 	//Greater than 30, we are too sparse for switching
 	if(average_distance >= MAX_AVERAGE_CASE_DIFFERENCE){

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -10201,42 +10201,26 @@ static inline u_int8_t is_switch_exhaustive_switch(generic_type_t* switching_on_
 		return FALSE;
 	}
 
-	//The range of all possible enum values
-	int32_t range = max_enum_value - min_enum_value + 1;
-
-	//Define a bytemap of all potential enum values and wipe it all out to 0
-	u_int8_t value_map[range];
-	memset(value_map, 0, sizeof(u_int8_t) * range);
-
 	/**
-	 * Let's now go through and fill out the byte map that we've made
-	 * with all of the values in the enumeration table. When we're done,
-	 * if this is switch eligible we'd have an array like: [1, 1, 1, 1, 1, 1].
-	 * If it's not, we may have something like [1, 1, 0, 1, 1] where there
-	 * are gaps in the exhaustive range
+	 * Check 2: if the average distance between values does not exactly equal
+	 * 1, then the switch is not exhaustive. If it does equal 1, then it is
+	 * exhaustive because we already know that the upper and lower bounds exactly
+	 * match the enum upper and lower bounds
 	 */
-	for(int32_t i = 0; i < switch_statement_values->current_index; i++){
-		//Extract the value
-		int32_t value = dynamic_integer_array_get_at(switch_statement_values, i);
+	int64_t average_distance = 0;
+	for(int32_t i = 1; i < switch_statement_values->current_index; i++){
+		int32_t first_value = switch_statement_values->internal_array[i - 1];
+		int32_t second_value = switch_statement_values->internal_array[i];
 
-		//Fill out that this exists now
-		value_map[value - min_enum_value] = TRUE;
+		average_distance += (second_value - first_value);
 	}
 
-	/**
-	 * Now for our final check - if any of the indices
-	 * here have 0, that means that that value in the enum
-	 * range simply doesn't exist. If we see that, we
-	 * fail out
-	 */
-	for(int32_t i = 0; i < range; i++){
-		if(value_map[i] == FALSE){
-			return FALSE;
-		}
-	}
+	//Compute the average distance by dividing by the number of distances(n-1 for n numbers)
+	average_distance /= (switch_statement_values->current_index - 1);
 
-	//If we survived to here then it worked
-	return TRUE;
+	printf("AVERAGE DISTANCE IS %ld\n", average_distance);
+
+	return average_distance != 1 ? FALSE : TRUE;
 }
 
 

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -7782,6 +7782,8 @@ static u_int8_t enum_definer(ollie_token_stream_t* token_stream){
 	lexitem_t lookahead;
 	//Reserve space for the type name
 	dynamic_string_t type_name = dynamic_string_alloc();
+	//Allocate the array for our sorted integer values
+	dynamic_integer_array_t sorted_integer_values = dynamic_integer_array_alloc();
 
 	//Add the enum intro in
 	dynamic_string_set(&type_name, "enum ");
@@ -8128,6 +8130,9 @@ static u_int8_t enum_definer(ollie_token_stream_t* token_stream){
 	generic_type_t* immutable_alias = create_aliased_type(alias_name.string, immutable_enum_type, parser_line_num, NOT_MUTABLE);
 	//Once we've made the aliased type, we can record it in the symbol table
 	insert_type(type_symtab, create_type_record(immutable_alias));
+
+	//Destroy now that we're done
+	dynamic_integer_array_dealloc(&sorted_integer_values);
 
 	//This is a successful creation
 	return SUCCESS;
@@ -10122,55 +10127,8 @@ static inline u_int8_t is_type_exhaustive_switch_eligible(generic_type_t* type){
 		return FALSE;
 	}
 	
-	//Extract for convenience
-	dynamic_array_t* enumeration_table = &(type->internal_types.enumeration_table);
-
-	/**
-	 * Remember that in Ollie, users are able to assign enum values their
-	 * own types. This means that values may *not* always be 1 apart from
-	 * each other. We'll need to check and see if all of the values inside of
-	 * the enumeration are in fact 1 apart
-	 */
-	int32_t min_enum_value = type->min_enum_value;
-	int32_t max_enum_value = type->max_enum_value;
-
-	//The range of all possible enum values
-	int32_t enum_range = max_enum_value - min_enum_value + 1;
-
-	//Define a bytemap of all potential enum values and wipe it all out to 0
-	u_int8_t value_map[enum_range];
-	memset(value_map, 0, sizeof(u_int8_t) * enum_range);
-
-	/**
-	 * Let's now go through and fill out the byte map that we've made
-	 * with all of the values in the enumeration table. When we're done,
-	 * if this is switch eligible we'd have an array like: [1, 1, 1, 1, 1, 1].
-	 * If it's not, we may have something like [1, 1, 0, 1, 1] where there
-	 * are gaps in the exhaustive range
-	 */
-	for(int32_t i = 0; i < enumeration_table->current_index; i++){
-		//Extract the members enum value
-		symtab_variable_record_t* member = dynamic_array_get_at(enumeration_table, i);
-		int32_t raw_enum_value = member->enum_member_value;
-
-		//Fill out that this exists now
-		value_map[raw_enum_value - min_enum_value] = TRUE;
-	}
-
-	/**
-	 * Now for our final check - if any of the indices
-	 * here have 0, that means that that value in the enum
-	 * range simply doesn't exist. If we see that, we
-	 * fail out
-	 */
-	for(int32_t i = 0; i < enum_range; i++){
-		if(value_map[i] == FALSE){
-			return FALSE;
-		}
-	}
-	
-	//If we survived to here then we're true
-	return TRUE;
+	//If the enum type is contiguous, then we do have an exhaustive switch eligible type
+	return type->is_contiguous_enum == TRUE ? TRUE: FALSE;
 }
 
 

--- a/oc/compiler/type_system/type_system.h
+++ b/oc/compiler/type_system/type_system.h
@@ -174,6 +174,8 @@ struct generic_type_t{
 	type_class_t type_class;
 	//Is this an anonymous type? Anonymous types have *no* name
 	u_int8_t is_anonymous;
+	//Is this a contiguous enum type? Contiguous enum types are enums where each value is 1 apart
+	u_int8_t is_contiguous_enum;
 };
 
 

--- a/oc/test_files/barely_not_contiguous_in.ol
+++ b/oc/test_files/barely_not_contiguous_in.ol
@@ -1,0 +1,22 @@
+/**
+ * Author: Jack Robbins
+ * Put our contiguous in detection to the test by having one that's just on the edge of being contiguous
+ */
+
+pub fn barely_not_contiguous_in(x:i32) -> i32 {
+	let result:mut i32 = 5;
+
+	//Almost there but not quite - there's a gap between -1 and 1
+	if(x in (-1, 2, 3, 1)) {
+		result *= 10;
+	} else {
+		result -= 2;
+	}
+
+	ret result;
+}
+
+pub fn main() -> i32 {
+	OUNIT: [exit_status = 50]
+	ret @barely_not_contiguous_in(3);
+}

--- a/oc/test_files/contiguous_in_unsigned_comparator.ol
+++ b/oc/test_files/contiguous_in_unsigned_comparator.ol
@@ -1,0 +1,22 @@
+/**
+ * Author: Jack Robbins
+ * Verify that we have the correct conditional move types for a contigious in with an unsigned comparator
+ */
+
+pub fn unsigned_comparator_in(x:u32) -> i32 {
+	let result:mut i32 = 5;
+
+	if(x in (1, 2, 4, 3, 7, 6, 5, 8, 10, 9)) {
+		result++;
+	} else {
+		result--;
+	}
+
+	ret result;
+}
+
+
+pub fn main() -> i32 {
+	OUNIT: [exit_status = 10]
+	ret @unsigned_comparator_in(7u) + @unsigned_comparator_in(0u);
+}


### PR DESCRIPTION
[Front End]: Ollie in statements with a contiguous range are automatically converted to an efficient conditional move chain

Closes #1071 
Closes #1072 
Closes #1073 