### PR TITLE
[Type System]: fixes to get_operand_type and rework of type widening

### DIFF
--- a/oc/compiler/cfg/cfg.c
+++ b/oc/compiler/cfg/cfg.c
@@ -6089,7 +6089,7 @@ static inline cfg_result_package_t lower_in_expression_to_conditional_move_chain
 		add_statement(current_block, comparison_instruction);
 
 		//Get the operand type base don the two types provided
-		operand_type = get_operand_type_for_logical_operation(type_symtab, conditional_expression_variable->type, in_constant_variable->type);
+		operand_type = get_operand_type_for_relational_operation(type_symtab, conditional_expression_variable->type, in_constant_variable->type);
 
 	} else {
 		//Unpack it first
@@ -6099,7 +6099,7 @@ static inline cfg_result_package_t lower_in_expression_to_conditional_move_chain
 		add_statement(current_block, comparison_instruction);
 
 		//Get the operand type base don the two types provided
-		operand_type = get_operand_type_for_logical_operation(type_symtab, conditional_expression_variable->type, in_constant->type);
+		operand_type = get_operand_type_for_relational_operation(type_symtab, conditional_expression_variable->type, in_constant->type);
 	}
 
 	/**
@@ -6145,7 +6145,7 @@ static inline cfg_result_package_t lower_in_expression_to_conditional_move_chain
 			add_statement(current_block, comparison_instruction);
 
 			//Get the operand type base don the two types provided
-			operand_type = get_operand_type_for_logical_operation(type_symtab, conditional_expression_variable->type, in_constant_variable->type);
+			operand_type = get_operand_type_for_relational_operation(type_symtab, conditional_expression_variable->type, in_constant_variable->type);
 
 		} else {
 			//Unpack it first
@@ -6155,7 +6155,7 @@ static inline cfg_result_package_t lower_in_expression_to_conditional_move_chain
 			add_statement(current_block, comparison_instruction);
 
 			//Get the operand type base don the two types provided
-			operand_type = get_operand_type_for_logical_operation(type_symtab, conditional_expression_variable->type, in_constant->type);
+			operand_type = get_operand_type_for_relational_operation(type_symtab, conditional_expression_variable->type, in_constant->type);
 		}
 
 		/**

--- a/oc/compiler/instruction_selector/instruction_selector.c
+++ b/oc/compiler/instruction_selector/instruction_selector.c
@@ -391,9 +391,9 @@ static inline generic_type_t* get_destination_type_for_binary_operation_instruct
 			case DOUBLE_EQUALS:
 			case NOT_EQUALS:
 				if(instruction->operands.oir.operand2 != NULL){
-					destination_type = get_operand_type_for_logical_operation(cfg_reference->type_symtab, 
-															   					instruction->operands.oir.operand1->type,
-															   					instruction->operands.oir.operand2->type);
+					destination_type = get_operand_type_for_relational_operation(cfg_reference->type_symtab, 
+															   					 instruction->operands.oir.operand1->type,
+															   					 instruction->operands.oir.operand2->type);
 				} else {
 					destination_type = instruction->operands.oir.operand1->type;
 				}

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -8591,9 +8591,9 @@ static u_int8_t enum_definer(ollie_token_stream_t* token_stream){
 	}
 
 	//Now, based on our largest value, we need to determine the bit-width needed for this
-	//field. Does it need to be stored internally as a u8, u16, u32, or u64?
+	//field. Does it need to be stored internally as a i8, i16, i32, or i64?
 	//This will *always* be the immutable version of the type
-	generic_type_t* type_needed = determine_required_minimum_unsigned_integer_type_size(largest_value);
+	generic_type_t* type_needed = determine_required_minimum_signed_integer_type_size(largest_value);
 
 	//Store this in the enum
 	mutable_enum_type->internal_values.enum_integer_type = type_needed;

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -2600,8 +2600,8 @@ static generic_ast_node_t* paramcount_statement(ollie_token_stream_t* token_stre
 	//Let's now allocate the final node and give it back
 	generic_ast_node_t* paramcount_node = ast_node_alloc(AST_NODE_TYPE_PARAMCOUNT_STMT, SIDE_TYPE_RIGHT);
 
-	//The type is always a u32
-	paramcount_node->inferred_type = immut_u32;
+	//The type is always an i32
+	paramcount_node->inferred_type = immut_i32;
 	paramcount_node->line_number = parser_line_num;
 
 	//Store the paramcount variable here - we will need this for down the road
@@ -5439,6 +5439,9 @@ static generic_ast_node_t* relational_expression(ollie_token_stream_t* token_str
 	generic_ast_node_t* temp_holder;
 	//For holding the right child
 	generic_ast_node_t* right_child;
+	//Holders for our left and right types
+	generic_type_t* left_hand_type;
+	generic_type_t* right_hand_type;
 	//The return type
 	generic_type_t* return_type;
 	//Track whether temp and right child collapsed to constants
@@ -5505,6 +5508,10 @@ static generic_ast_node_t* relational_expression(ollie_token_stream_t* token_str
 				return print_and_return_error(info, parser_line_num);
 			}
 
+			//Cache the types before comparison
+			left_hand_type = temp_holder->inferred_type;
+			right_hand_type = right_child->inferred_type;
+
 			//The return type is always the left child's type
 			return_type = determine_type_compatability_for_expression(type_symtab, temp_holder, right_child, op.tok);
 
@@ -5512,6 +5519,27 @@ static generic_ast_node_t* relational_expression(ollie_token_stream_t* token_str
 			if(return_type == NULL){
 				sprintf(info, "Types %s and %s cannot be applied to operator %s", temp_holder->inferred_type->type_name.string, right_child->inferred_type->type_name.string, operator_token_to_string(op.tok));
 				return print_and_return_error(info, parser_line_num);
+			}
+
+			/**
+			 * Once we know that the types are in fact compatable, since we are performing
+			 * a comparison operation we will want to warn the user if they are comparing
+			 * between signed/unsigned integer types
+			 */
+			if(is_integer_type(left_hand_type) == TRUE && is_integer_type(right_hand_type) == TRUE){
+				/**
+				 * Type signage mismatch. This is *not* an error or illegal, but it is 
+				 * a foot-gun and we want to warn about this. There are legitimate
+				 * cases where you may want to do this but they are rare
+				 */
+				if(is_type_signed(left_hand_type) != is_type_signed(right_hand_type)){
+					sprintf(info, "Comparison(%s) between types %s and %s has a signedness mismatch and may produce unexpected behavior",
+			 						operator_token_to_string(op.tok),
+			 						left_hand_type->type_name.string,
+			 						right_hand_type->type_name.string);
+					num_warnings++;
+					print_parse_message(MESSAGE_TYPE_WARNING, info, parser_line_num);
+				}
 			}
 
 			//If these are both constants, we can skip the entire allocation

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -5526,7 +5526,8 @@ static generic_ast_node_t* relational_expression(ollie_token_stream_t* token_str
 			 * a comparison operation we will want to warn the user if they are comparing
 			 * between signed/unsigned integer types
 			 */
-			if(is_integer_type(left_hand_type) == TRUE && is_integer_type(right_hand_type) == TRUE){
+			if(temp_holder_is_constant == FALSE && right_child_is_constant == FALSE
+				&& is_integer_type(left_hand_type) == TRUE && is_integer_type(right_hand_type) == TRUE){
 				/**
 				 * Type signage mismatch. This is *not* an error or illegal, but it is 
 				 * a foot-gun and we want to warn about this. There are legitimate

--- a/oc/compiler/parser/parser.c
+++ b/oc/compiler/parser/parser.c
@@ -5617,6 +5617,9 @@ static generic_ast_node_t* equality_expression(ollie_token_stream_t* token_strea
 	generic_ast_node_t* temp_holder;
 	//For holding the right child
 	generic_ast_node_t* right_child;
+	//Holders for our left and right types
+	generic_type_t* left_hand_type;
+	generic_type_t* right_hand_type;
 	//Holder for the return type
 	generic_type_t* return_type;
 	//Flags for whether or not both of these is constant
@@ -5677,6 +5680,10 @@ static generic_ast_node_t* equality_expression(ollie_token_stream_t* token_strea
 			sprintf(info, "Type %s is invalid for operator %s", right_child->inferred_type->type_name.string, operator_token_to_string(op.tok));
 			return print_and_return_error(info, parser_line_num);
 		}
+		
+		//Cache these before we go on
+		left_hand_type = temp_holder->inferred_type;
+		right_hand_type = right_child->inferred_type;
 
 		//Get the return type and perform any needed coercions
 		return_type = determine_type_compatability_for_expression(type_symtab, temp_holder, right_child, op.tok);
@@ -5685,6 +5692,28 @@ static generic_ast_node_t* equality_expression(ollie_token_stream_t* token_strea
 		if(sub_tree_root->inferred_type == NULL){
 			sprintf(info, "Types %s and %s cannot be applied to operator %s", temp_holder->inferred_type->type_name.string, right_child->inferred_type->type_name.string, operator_token_to_string(op.tok));
 			return print_and_return_error(info, parser_line_num);
+		}
+
+		/**
+		 * Once we know that the types are in fact compatable, since we are performing
+		 * a comparison operation we will want to warn the user if they are comparing
+		 * between signed/unsigned integer types
+		 */
+		if(temp_holder_is_constant == FALSE && right_child_is_constant == FALSE
+			&& is_integer_type(left_hand_type) == TRUE && is_integer_type(right_hand_type) == TRUE){
+			/**
+			 * Type signage mismatch. This is *not* an error or illegal, but it is 
+			 * a foot-gun and we want to warn about this. There are legitimate
+			 * cases where you may want to do this but they are rare
+			 */
+			if(is_type_signed(left_hand_type) != is_type_signed(right_hand_type)){
+				sprintf(info, "Comparison(%s) between types %s and %s has a signedness mismatch and may produce unexpected behavior",
+								operator_token_to_string(op.tok),
+								left_hand_type->type_name.string,
+								right_hand_type->type_name.string);
+				num_warnings++;
+				print_parse_message(MESSAGE_TYPE_WARNING, info, parser_line_num);
+			}
 		}
 
 		//If these are both constants, then we can invoke the appropriate simplifier

--- a/oc/compiler/type_system/type_system.c
+++ b/oc/compiler/type_system/type_system.c
@@ -3096,11 +3096,11 @@ generic_type_t* get_operand_type_for_logical_operation(void* symtab, generic_typ
 	 * Extract out enum types now and use their underlying
 	 * integer type instead
 	 */
-	if(a->type_class == TYPE_CLASS_ELABORATIVE){
+	if(a->type_class == TYPE_CLASS_ENUMERATED){
 		a = a->internal_values.enum_integer_type;
 	}
 
-	if(b->type_class == TYPE_CLASS_ELABORATIVE){
+	if(b->type_class == TYPE_CLASS_ENUMERATED){
 		b = b->internal_values.enum_integer_type;
 	}
 
@@ -3130,24 +3130,20 @@ generic_type_t* get_operand_type_for_relational_operation(void* symtab, generic_
 	 * Extract out enum types now and use their underlying
 	 * integer type instead
 	 */
-	if(a->type_class == TYPE_CLASS_ELABORATIVE){
-		printf("HERE\n");
+	if(a->type_class == TYPE_CLASS_ENUMERATED){
 		a = a->internal_values.enum_integer_type;
 	}
 
-	if(b->type_class == TYPE_CLASS_ELABORATIVE){
-		printf("HERE1\n");
+	if(b->type_class == TYPE_CLASS_ENUMERATED){
 		b = b->internal_values.enum_integer_type;
 	}
 
 	//Perform any floating point coercion first
 	handle_floating_point_coercion(symtab, &a, &b);
 
-		printf("HERE2\n");
 	//Widen it
 	basic_type_widening_type_coercion(symtab, &a, &b);
 
-		printf("HERE3\n");
 	//Now do the signedness coercion
 	basic_type_signedness_coercion(symtab, &a, &b);
 

--- a/oc/compiler/type_system/type_system.c
+++ b/oc/compiler/type_system/type_system.c
@@ -3089,29 +3089,32 @@ void add_return_type_to_signature(function_type_t* signature, generic_type_t* re
  * coercion here.
  */
 generic_type_t* get_operand_type_for_logical_operation(void* symtab, generic_type_t* type_a, generic_type_t* type_b){
+	generic_type_t* a = type_a;
+	generic_type_t* b = type_b;
+
 	/**
 	 * Extract out enum types now and use their underlying
 	 * integer type instead
 	 */
-	if(type_a->type_class == TYPE_CLASS_ELABORATIVE){
-		type_a = type_a->internal_values.enum_integer_type;
+	if(a->type_class == TYPE_CLASS_ELABORATIVE){
+		a = a->internal_values.enum_integer_type;
 	}
 
-	if(type_b->type_class == TYPE_CLASS_ELABORATIVE){
-		type_b = type_b->internal_values.enum_integer_type;
+	if(b->type_class == TYPE_CLASS_ELABORATIVE){
+		b = b->internal_values.enum_integer_type;
 	}
 
 	//Perform any floating point coercion first
-	handle_floating_point_coercion(symtab, &type_a, &type_b);
+	handle_floating_point_coercion(symtab, &a, &b);
 
 	//Widen it
-	basic_type_widening_type_coercion(symtab, &type_a, &type_b);
+	basic_type_widening_type_coercion(symtab, &a, &b);
 
 	//Now do the signedness coercion
-	basic_type_signedness_coercion(symtab, &type_a, &type_b);
+	basic_type_signedness_coercion(symtab, &a, &b);
 
 	//Give back whatever we got
-	return type_a;
+	return a;
 }
 
 
@@ -3120,63 +3123,36 @@ generic_type_t* get_operand_type_for_logical_operation(void* symtab, generic_typ
  * and signedness coercion here.
  */
 generic_type_t* get_operand_type_for_relational_operation(void* symtab, generic_type_t* type_a, generic_type_t* type_b){
-	type_symtab_t* type_corrected_symtab = symtab;
-
-	//Are these floats or not?
-	u_int8_t typea_is_float = IS_FLOATING_POINT(type_a);
-	u_int8_t typeb_is_float = IS_FLOATING_POINT(type_b);
+	generic_type_t* a = type_a;
+	generic_type_t* b = type_b;
 
 	/**
-	 * Case 1: both floats - largest one wins
-	 *
-	 *
-	 * TODO WHOLE FLOW SHOULD BE REWORKED - too much comparison here
+	 * Extract out enum types now and use their underlying
+	 * integer type instead
 	 */
-	if(typea_is_float == TRUE && typeb_is_float == TRUE){
-		if(type_a->type_size > type_b->type_size){
-			return type_a;
-		} else {
-			return type_b;
-		}
-
-	/**
-	 * Case 2: type_a is a float, b is not
-	 */
-	} else if(typea_is_float == TRUE && typeb_is_float == FALSE){
-		//If type_a is large enough, just use that
-		if(type_a->type_size >= type_b->type_size){
-			return type_a;
-		//Otherwise just force an f64
-		} else {
-			return lookup_type_name_only(type_corrected_symtab, "f64", NOT_MUTABLE)->type;
-		}
-
-	/**
-	 * Case 3: type_b is a float, a is not
-	 */
-	} else if(typea_is_float == FALSE && typeb_is_float == TRUE){
-		//If type_b is large enough, just use that
-		if(type_b->type_size >= type_a->type_size){
-			return type_b;
-		//Otherwise just force an f64
-		} else {
-			return lookup_type_name_only(type_corrected_symtab, "f64", NOT_MUTABLE)->type;
-		}
-
-	/**
-	 * Case 4: no floats - largest wins. We will also be performing
-	 * signedness coercion
-	 */
-	} else {
-		//First widen it
-		basic_type_widening_type_coercion(symtab, &type_a, &type_b);
-
-		//Now do the signedness coercion
-		basic_type_signedness_coercion(symtab, &type_a, &type_b);
-
-		//Give back whatever we ended up with
-		return type_a;
+	if(a->type_class == TYPE_CLASS_ELABORATIVE){
+		printf("HERE\n");
+		a = a->internal_values.enum_integer_type;
 	}
+
+	if(b->type_class == TYPE_CLASS_ELABORATIVE){
+		printf("HERE1\n");
+		b = b->internal_values.enum_integer_type;
+	}
+
+	//Perform any floating point coercion first
+	handle_floating_point_coercion(symtab, &a, &b);
+
+		printf("HERE2\n");
+	//Widen it
+	basic_type_widening_type_coercion(symtab, &a, &b);
+
+		printf("HERE3\n");
+	//Now do the signedness coercion
+	basic_type_signedness_coercion(symtab, &a, &b);
+
+	//Give back whatever we got
+	return a;
 }
 
 

--- a/oc/compiler/type_system/type_system.c
+++ b/oc/compiler/type_system/type_system.c
@@ -2993,6 +2993,8 @@ generic_type_t* get_operand_type_for_logical_operation(void* symtab, generic_typ
 
 	/**
 	 * Case 1: both floats - largest one wins
+	 *
+	 * TODO WHOLE FLOW SHOULD BE REWORKED - too much comparison here
 	 */
 	if(typea_is_float == TRUE && typeb_is_float == TRUE){
 		if(type_a->type_size > type_b->type_size){
@@ -3026,14 +3028,17 @@ generic_type_t* get_operand_type_for_logical_operation(void* symtab, generic_typ
 		}
 
 	/**
-	 * Case 4: no floats - largest wins
+	 * Case 4: no floats - largest wins. We will be doing basic type widening coercion
 	 */
 	} else {
-		if(type_a->type_size > type_b->type_size){
-			return type_a;
-		} else {
-			return type_b;
-		}
+		//First widen it
+		basic_type_widening_type_coercion(&type_a, &type_b);
+
+		//Now do the signedness coercion
+		basic_type_signedness_coercion(symtab, &type_a, &type_b);
+
+		//Give back whatever we ended up with
+		return type_a;
 	}
 }
 
@@ -3051,6 +3056,9 @@ generic_type_t* get_operand_type_for_relational_operation(void* symtab, generic_
 
 	/**
 	 * Case 1: both floats - largest one wins
+	 *
+	 *
+	 * TODO WHOLE FLOW SHOULD BE REWORKED - too much comparison here
 	 */
 	if(typea_is_float == TRUE && typeb_is_float == TRUE){
 		if(type_a->type_size > type_b->type_size){

--- a/oc/compiler/type_system/type_system.c
+++ b/oc/compiler/type_system/type_system.c
@@ -1025,9 +1025,39 @@ static inline void basic_type_widening_type_coercion(generic_type_t** a, generic
  * no float to int or vice versa), we will only widen the size
  */
 static inline void widen_basic_type_to_given_size(type_symtab_t* symtab, generic_type_t** type, int32_t target_size){
+	//Just to help us stay organized
+	typedef enum {
+		WIDEN_SIGNED,
+		WIDEN_UNSIGNED,
+		WIDEN_FLOAT,
+	} widening_type_t;
+
+	//Let's first determine what general classication of type this is
+	widening_type_t classification;
+	switch((*type)->basic_type_token){
+		case F32:
+		case F64:
+
+		case I8:
+		case I16:
+		case I32:
+		case I64:
+
+		case CHAR:
+		case BOOL:
+		case U8:
+		case U16:
+		case U32:
+		case U64:
+
+		default:
+			fprintf(stderr, "Fatal internal compiler error. Invalid basic type given to type widener\n");
+			exit(1);
+	}
+
+
 
 }
-
 
 
 /**
@@ -1048,7 +1078,9 @@ static inline void basic_type_widening_type_coercion_v2(type_symtab_t* symtab, g
 		widen_to_size = b_type_size;
 	}
 
-
+	//Let the helper perform the widening that is needed
+	widen_basic_type_to_given_size(symtab, a, widen_to_size);
+	widen_basic_type_to_given_size(symtab, b, widen_to_size);
 }
 
 

--- a/oc/compiler/type_system/type_system.c
+++ b/oc/compiler/type_system/type_system.c
@@ -1037,11 +1037,15 @@ static inline void widen_basic_type_to_given_size(type_symtab_t* symtab, generic
 	switch((*type)->basic_type_token){
 		case F32:
 		case F64:
+			classification = WIDEN_FLOAT;
+			break;
 
 		case I8:
 		case I16:
 		case I32:
 		case I64:
+			classification = WIDEN_SIGNED;
+			break;
 
 		case CHAR:
 		case BOOL:
@@ -1049,14 +1053,86 @@ static inline void widen_basic_type_to_given_size(type_symtab_t* symtab, generic
 		case U16:
 		case U32:
 		case U64:
+			classification = WIDEN_UNSIGNED;
+			break;
 
 		default:
 			fprintf(stderr, "Fatal internal compiler error. Invalid basic type given to type widener\n");
 			exit(1);
 	}
 
+	/**
+	 * Now based on the general class of type that we got, we will widen as we
+	 * see fit here
+	 */
+	switch(classification){
+		case WIDEN_FLOAT:
+			switch(target_size){
+				//Do nothing, all floats are at least 4 bytes large
+				case 4:
+					break;
 
+				case 8:
+					*type = lookup_type_name_only(symtab, "f64", (*type)->mutability)->type;
+					break;
 
+				default:
+					fprintf(stderr, "Fatal internal compiler error. Invalid widen to size of %d given for float\n", target_size);
+					exit(1);
+			}
+
+			break;
+
+		case WIDEN_SIGNED:
+			switch(target_size){
+				//Do nothing - all ints are at least 1 byte large
+				case 1:
+					break;
+				
+				case 2:
+					*type = lookup_type_name_only(symtab, "i16", (*type)->mutability)->type;
+					break;
+
+				case 4:
+					*type = lookup_type_name_only(symtab, "i32", (*type)->mutability)->type;
+					break;
+
+				case 8:
+					*type = lookup_type_name_only(symtab, "i64", (*type)->mutability)->type;
+					break;
+
+				default:
+					fprintf(stderr, "Fatal internal compiler error. Invalid widen to size of %d given for signed integer\n", target_size);
+					exit(1);
+			}
+
+			break;
+
+		case WIDEN_UNSIGNED:
+			switch(target_size){
+				//Do nothing - all ints are at least 1 byte large
+				case 1:
+					break;
+				
+				case 2:
+					*type = lookup_type_name_only(symtab, "u16", (*type)->mutability)->type;
+					break;
+
+				case 4:
+					*type = lookup_type_name_only(symtab, "u32", (*type)->mutability)->type;
+					break;
+
+				case 8:
+					*type = lookup_type_name_only(symtab, "u64", (*type)->mutability)->type;
+					break;
+
+				default:
+					fprintf(stderr, "Fatal internal compiler error. Invalid widen to size of %d given for unsigned integer\n", target_size);
+					exit(1);
+			}
+
+			break;
+	}
 }
 
 

--- a/oc/compiler/type_system/type_system.c
+++ b/oc/compiler/type_system/type_system.c
@@ -1005,6 +1005,8 @@ static inline void basic_type_signedness_coercion(type_symtab_t* symtab, generic
  * Apply standard coercion rules for basic types
  *
  * TODO IS THIS RIGHT???????
+ *
+ * I don't think that this is at all correct
  */
 static inline void basic_type_widening_type_coercion(generic_type_t** a, generic_type_t** b){
 	//Whomever has the largest size wins
@@ -1015,6 +1017,13 @@ static inline void basic_type_widening_type_coercion(generic_type_t** a, generic
 		//Set a to equal b
 		*a = *b;
 	}
+}
+
+
+//TODO - we need to actually scale up the types appropriately. We cannot just blindly assign
+//stuff over
+static inline void basic_type_widening_type_coercion_v2(generic_type_t** a, generic_type_t** b){
+
 }
 
 

--- a/oc/compiler/type_system/type_system.c
+++ b/oc/compiler/type_system/type_system.c
@@ -1002,25 +1002,6 @@ static inline void basic_type_signedness_coercion(type_symtab_t* symtab, generic
 
 
 /**
- * Apply standard coercion rules for basic types
- *
- * TODO IS THIS RIGHT???????
- *
- * I don't think that this is at all correct
- */
-static inline void basic_type_widening_type_coercion(generic_type_t** a, generic_type_t** b){
-	//Whomever has the largest size wins
-	if((*a)->type_size > (*b)->type_size){
-		//Set b to equal a
-		*b = *a;
-	} else if((*a)->type_size < (*b)->type_size){
-		//Set a to equal b
-		*a = *b;
-	}
-}
-
-
-/**
  * Widen the given type to the target size. We will not change the variety of our type(i.e. no signed changes,
  * no float to int or vice versa), we will only widen the size
  */
@@ -1141,7 +1122,7 @@ static inline void widen_basic_type_to_given_size(type_symtab_t* symtab, generic
  * existing type class based on the overall largest size. For example, if we have an i8 and a u32,
  * we would expand the i8 to an i32(no signedness change)
  */
-static inline void basic_type_widening_type_coercion_v2(type_symtab_t* symtab, generic_type_t** a, generic_type_t** b){
+static inline void basic_type_widening_type_coercion(type_symtab_t* symtab, generic_type_t** a, generic_type_t** b){
 	//Extract these for convenience
 	int32_t a_type_size = (*a)->type_size;
 	int32_t b_type_size = (*b)->type_size;
@@ -1380,7 +1361,7 @@ generic_type_t* determine_ternary_compatibility(void* symtab, generic_type_t** a
 	basic_type_signedness_coercion(symtab, a, b);
 
 	//We already know that we only have basic types here. We can apply the standard widening conversion
-	basic_type_widening_type_coercion(a, b);
+	basic_type_widening_type_coercion(symtab, a, b);
 
 	//We'll return a final comparison type of bool 
 	return *a;
@@ -1551,7 +1532,7 @@ generic_type_t* determine_compatability_and_coerce(void* symtab, generic_type_t*
 
 			//We already know that these are basic types only here. We can
 			//apply the standard widening type coercion
-			basic_type_widening_type_coercion(a, b);
+			basic_type_widening_type_coercion(symtab, a, b);
 
 			//Give back a
 			return *a;
@@ -1635,7 +1616,7 @@ generic_type_t* determine_compatability_and_coerce(void* symtab, generic_type_t*
 
 			//We already know that these are basic types only here. We can
 			//apply the standard widening type coercion
-			basic_type_widening_type_coercion(a, b);
+			basic_type_widening_type_coercion(symtab, a, b);
 
 			//Give back a
 			return lookup_type_name_only(symtab, "bool", (*a)->mutability)->type;
@@ -1658,7 +1639,7 @@ generic_type_t* determine_compatability_and_coerce(void* symtab, generic_type_t*
 
 			//We already know that these are basic types only here. We can
 			//apply the standard widening type coercion
-			basic_type_widening_type_coercion(a, b);
+			basic_type_widening_type_coercion(symtab, a, b);
 		
 			//Give this back once down
 			return *a;
@@ -1679,7 +1660,7 @@ generic_type_t* determine_compatability_and_coerce(void* symtab, generic_type_t*
 
 			//We already know that we only have basic types here. We can apply
 			//the standard widening conversion
-			basic_type_widening_type_coercion(a, b);
+			basic_type_widening_type_coercion(symtab, a, b);
 
 			//We'll give back *a once we're finished
 			return *a;
@@ -1757,7 +1738,7 @@ generic_type_t* determine_compatability_and_coerce(void* symtab, generic_type_t*
 
 			//We already know that we only have basic types here. We can apply
 			//the standard widening conversion
-			basic_type_widening_type_coercion(a, b);
+			basic_type_widening_type_coercion(symtab, a, b);
 
 			//We need to use either a bool or an i8 if they're signed. Internally,
 			//these are treated the same
@@ -3165,7 +3146,7 @@ generic_type_t* get_operand_type_for_logical_operation(void* symtab, generic_typ
 	 */
 	} else {
 		//First widen it
-		basic_type_widening_type_coercion(&type_a, &type_b);
+		basic_type_widening_type_coercion(symtab, &type_a, &type_b);
 
 		//Now do the signedness coercion
 		basic_type_signedness_coercion(symtab, &type_a, &type_b);
@@ -3230,7 +3211,7 @@ generic_type_t* get_operand_type_for_relational_operation(void* symtab, generic_
 	 */
 	} else {
 		//First widen it
-		basic_type_widening_type_coercion(&type_a, &type_b);
+		basic_type_widening_type_coercion(symtab, &type_a, &type_b);
 
 		//Now do the signedness coercion
 		basic_type_signedness_coercion(symtab, &type_a, &type_b);

--- a/oc/compiler/type_system/type_system.c
+++ b/oc/compiler/type_system/type_system.c
@@ -2971,7 +2971,7 @@ void add_return_type_to_signature(function_type_t* signature, generic_type_t* re
 
 /**
  * Compute the operand type for a logical and/or operation. We perform floating point
- * coercion here. j
+ * coercion here.
  */
 generic_type_t* get_operand_type_for_logical_operation(void* symtab, generic_type_t* type_a, generic_type_t* type_b){
 	type_symtab_t* type_corrected_symtab = symtab;
@@ -3029,7 +3029,7 @@ generic_type_t* get_operand_type_for_logical_operation(void* symtab, generic_typ
 
 /**
  * Compute the operand type for a relational operation. We perform floating point
- * coercion here. j
+ * coercion here.
  */
 generic_type_t* get_operand_type_for_relational_operation(void* symtab, generic_type_t* type_a, generic_type_t* type_b){
 	type_symtab_t* type_corrected_symtab = symtab;

--- a/oc/compiler/type_system/type_system.c
+++ b/oc/compiler/type_system/type_system.c
@@ -1013,8 +1013,6 @@ static inline void widen_basic_type_to_given_size(type_symtab_t* symtab, generic
 		WIDEN_FLOAT,
 	} widening_type_t;
 
-	printf("TYPE IS %s\n", (*type)->type_name.string);
-
 	//Let's first determine what general classication of type this is
 	widening_type_t classification;
 	switch((*type)->basic_type_token){
@@ -3091,11 +3089,46 @@ void add_return_type_to_signature(function_type_t* signature, generic_type_t* re
  * coercion here.
  */
 generic_type_t* get_operand_type_for_logical_operation(void* symtab, generic_type_t* type_a, generic_type_t* type_b){
-	type_symtab_t* type_corrected_symtab = symtab;
+	/**
+	 * Extract out enum types now and use their underlying
+	 * integer type instead
+	 */
+	if(type_a->type_class == TYPE_CLASS_ELABORATIVE){
+		type_a = type_a->internal_values.enum_integer_type;
+	}
+
+	if(type_b->type_class == TYPE_CLASS_ELABORATIVE){
+		type_b = type_b->internal_values.enum_integer_type;
+	}
+
 
 	//Are these floats or not?
 	u_int8_t typea_is_float = IS_FLOATING_POINT(type_a);
 	u_int8_t typeb_is_float = IS_FLOATING_POINT(type_b);
+
+	/**
+	 * Cases 1 and 2 - type_a is not a float in both cases(most common)
+	 */
+	if(typea_is_float == FALSE){
+		/**
+		 * Case 1: type_a and type_b are both not floating point values
+		 */
+		if(typeb_is_float == FALSE){
+
+		} else {
+
+		}
+
+	/**
+	 * Cases 3 and 4 - type_a is a float in both cases(less common)
+	 */
+	} else {
+		if(typeb_is_float == FALSE){
+
+		} else {
+
+		}
+	}
 
 	/**
 	 * Case 1: both floats - largest one wins

--- a/oc/compiler/type_system/type_system.c
+++ b/oc/compiler/type_system/type_system.c
@@ -1003,6 +1003,8 @@ static inline void basic_type_signedness_coercion(type_symtab_t* symtab, generic
 
 /**
  * Apply standard coercion rules for basic types
+ *
+ * TODO IS THIS RIGHT???????
  */
 static inline void basic_type_widening_type_coercion(generic_type_t** a, generic_type_t** b){
 	//Whomever has the largest size wins
@@ -3029,7 +3031,7 @@ generic_type_t* get_operand_type_for_logical_operation(void* symtab, generic_typ
 
 /**
  * Compute the operand type for a relational operation. We perform floating point
- * coercion here.
+ * and signedness coercion here.
  */
 generic_type_t* get_operand_type_for_relational_operation(void* symtab, generic_type_t* type_a, generic_type_t* type_b){
 	type_symtab_t* type_corrected_symtab = symtab;
@@ -3073,14 +3075,18 @@ generic_type_t* get_operand_type_for_relational_operation(void* symtab, generic_
 		}
 
 	/**
-	 * Case 4: no floats - largest wins
+	 * Case 4: no floats - largest wins. We will also be performing
+	 * signedness coercion
 	 */
 	} else {
-		if(type_a->type_size > type_b->type_size){
-			return type_a;
-		} else {
-			return type_b;
-		}
+		//First widen it
+		basic_type_widening_type_coercion(&type_a, &type_b);
+
+		//Now do the signedness coercion
+		basic_type_signedness_coercion(symtab, &type_a, &type_b);
+
+		//Give back whatever we ended up with
+		return type_a;
 	}
 }
 

--- a/oc/compiler/type_system/type_system.c
+++ b/oc/compiler/type_system/type_system.c
@@ -1020,9 +1020,34 @@ static inline void basic_type_widening_type_coercion(generic_type_t** a, generic
 }
 
 
-//TODO - we need to actually scale up the types appropriately. We cannot just blindly assign
-//stuff over
-static inline void basic_type_widening_type_coercion_v2(generic_type_t** a, generic_type_t** b){
+/**
+ * Widen the given type to the target size. We will not change the variety of our type(i.e. no signed changes,
+ * no float to int or vice versa), we will only widen the size
+ */
+static inline void widen_basic_type_to_given_size(type_symtab_t* symtab, generic_type_t** type, int32_t target_size){
+
+}
+
+
+
+/**
+ * Apply standard widening coercion for basic types. All that this does is expand the 
+ * existing type class based on the overall largest size. For example, if we have an i8 and a u32,
+ * we would expand the i8 to an i32(no signedness change)
+ */
+static inline void basic_type_widening_type_coercion_v2(type_symtab_t* symtab, generic_type_t** a, generic_type_t** b){
+	//Extract these for convenience
+	int32_t a_type_size = (*a)->type_size;
+	int32_t b_type_size = (*b)->type_size;
+
+	//What size are we widening too? This is always the largest of the two
+	int32_t widen_to_size;
+	if(a_type_size > b_type_size){
+		widen_to_size = a_type_size;
+	} else {
+		widen_to_size = b_type_size;
+	}
+
 
 }
 

--- a/oc/compiler/type_system/type_system.c
+++ b/oc/compiler/type_system/type_system.c
@@ -1013,6 +1013,8 @@ static inline void widen_basic_type_to_given_size(type_symtab_t* symtab, generic
 		WIDEN_FLOAT,
 	} widening_type_t;
 
+	printf("TYPE IS %s\n", (*type)->type_name.string);
+
 	//Let's first determine what general classication of type this is
 	widening_type_t classification;
 	switch((*type)->basic_type_token){
@@ -1389,26 +1391,16 @@ generic_type_t* determine_compatability_and_coerce(void* symtab, generic_type_t*
 	*a = dealias_type(*a);
 	*b = dealias_type(*b);
 
-	//Special treatment based on a's type class
-	switch((*a)->type_class){
-		//Dereference the enum int type
-		case TYPE_CLASS_ENUMERATED:
-			*a = (*a)->internal_values.enum_integer_type;
-			break;
-		//Do nothing
-		default:
-			break;
+	/**
+	 * If a or b are enumerated types we will just go right
+	 * to their underlying integer types
+	 */
+	if((*a)->type_class == TYPE_CLASS_ENUMERATED){
+		*a = (*a)->internal_values.enum_integer_type;
 	}
 
-	//Special treatment based on b's type class
-	switch((*b)->type_class){
-		//Dereference the enum int type
-		case TYPE_CLASS_ENUMERATED:
-			*b = (*b)->internal_values.enum_integer_type;
-			break;
-		//Do nothing
-		default:
-			break;
+	if((*b)->type_class == TYPE_CLASS_ENUMERATED){
+		*b = (*b)->internal_values.enum_integer_type;
 	}
 	
 	/**

--- a/oc/compiler/type_system/type_system.c
+++ b/oc/compiler/type_system/type_system.c
@@ -3229,6 +3229,37 @@ void add_parameter_to_function_type(generic_type_t* function_type, generic_type_
 
 
 /**
+ * Determine if a type is an integer or not
+ */
+u_int8_t is_integer_type(generic_type_t* type){
+	//We must have a basic type for it to be signed
+	if(type->type_class != TYPE_CLASS_BASIC){
+		//By default everything else(addresses, etc) is not signed
+		return FALSE;
+	}
+
+	//If we get here there's a chance it could be signed
+	ollie_token_t basic_type_token = type->basic_type_token;
+
+	switch(basic_type_token){
+		case CHAR:
+		case BOOL:
+		case I8:
+		case U8:
+		case I16:
+		case U16:
+		case I32:
+		case U32:
+		case I64:
+		case U64:
+			return TRUE;
+		default:
+			return FALSE;
+	}
+}
+
+
+/**
  * Is a type signed?
  */
 u_int8_t is_type_signed(generic_type_t* type){

--- a/oc/compiler/type_system/type_system.c
+++ b/oc/compiler/type_system/type_system.c
@@ -3101,84 +3101,17 @@ generic_type_t* get_operand_type_for_logical_operation(void* symtab, generic_typ
 		type_b = type_b->internal_values.enum_integer_type;
 	}
 
+	//Perform any floating point coercion first
+	handle_floating_point_coercion(symtab, &type_a, &type_b);
 
-	//Are these floats or not?
-	u_int8_t typea_is_float = IS_FLOATING_POINT(type_a);
-	u_int8_t typeb_is_float = IS_FLOATING_POINT(type_b);
+	//Widen it
+	basic_type_widening_type_coercion(symtab, &type_a, &type_b);
 
-	/**
-	 * Cases 1 and 2 - type_a is not a float in both cases(most common)
-	 */
-	if(typea_is_float == FALSE){
-		/**
-		 * Case 1: type_a and type_b are both not floating point values
-		 */
-		if(typeb_is_float == FALSE){
+	//Now do the signedness coercion
+	basic_type_signedness_coercion(symtab, &type_a, &type_b);
 
-		} else {
-
-		}
-
-	/**
-	 * Cases 3 and 4 - type_a is a float in both cases(less common)
-	 */
-	} else {
-		if(typeb_is_float == FALSE){
-
-		} else {
-
-		}
-	}
-
-	/**
-	 * Case 1: both floats - largest one wins
-	 *
-	 * TODO WHOLE FLOW SHOULD BE REWORKED - too much comparison here
-	 */
-	if(typea_is_float == TRUE && typeb_is_float == TRUE){
-		if(type_a->type_size > type_b->type_size){
-			return type_a;
-		} else {
-			return type_b;
-		}
-
-	/**
-	 * Case 2: type_a is a float, b is not
-	 */
-	} else if(typea_is_float == TRUE && typeb_is_float == FALSE){
-		//If type_a is large enough, just use that
-		if(type_a->type_size >= type_b->type_size){
-			return type_a;
-		//Otherwise just force an f64
-		} else {
-			return lookup_type_name_only(type_corrected_symtab, "f64", NOT_MUTABLE)->type;
-		}
-
-	/**
-	 * Case 3: type_b is a float, a is not
-	 */
-	} else if(typea_is_float == FALSE && typeb_is_float == TRUE){
-		//If type_b is large enough, just use that
-		if(type_b->type_size >= type_a->type_size){
-			return type_b;
-		//Otherwise just force an f64
-		} else {
-			return lookup_type_name_only(type_corrected_symtab, "f64", NOT_MUTABLE)->type;
-		}
-
-	/**
-	 * Case 4: no floats - largest wins. We will be doing basic type widening coercion
-	 */
-	} else {
-		//First widen it
-		basic_type_widening_type_coercion(symtab, &type_a, &type_b);
-
-		//Now do the signedness coercion
-		basic_type_signedness_coercion(symtab, &type_a, &type_b);
-
-		//Give back whatever we ended up with
-		return type_a;
-	}
+	//Give back whatever we got
+	return type_a;
 }
 
 

--- a/oc/compiler/type_system/type_system.h
+++ b/oc/compiler/type_system/type_system.h
@@ -470,6 +470,11 @@ generic_type_t* dereference_type(generic_type_t* pointer_type);
 variable_size_t get_type_size(generic_type_t* type);
 
 /**
+ * Determine if a type is an integer or not
+ */
+u_int8_t is_integer_type(generic_type_t* type);
+
+/**
  * Is a type signed?
  */
 u_int8_t is_type_signed(generic_type_t* type);

--- a/oc/test_files/assign_unsigned_to_negative.ol
+++ b/oc/test_files/assign_unsigned_to_negative.ol
@@ -1,0 +1,13 @@
+/**
+ * Author: Jack Robbins
+ * Test the assignment of a negative number to an unsigned integer - should work just fine
+ */
+
+
+pub fn main() -> i32 {
+	//-5 in u8 form is really 251 unsigned
+	let ret_val:u8 = -5;
+
+	OUNIT: [exit_status = 251]
+	ret <u32>ret_val;
+}

--- a/oc/test_files/comparison_testing.ol
+++ b/oc/test_files/comparison_testing.ol
@@ -7,5 +7,6 @@ pub fn main() -> i32 {
 	let i:u32 = 2;
 	let j:i32 = 3;
 
+	OUNIT: [exit_status = 0]
 	ret j < i;
 }

--- a/oc/test_files/equals_operation_signed_unsigned.ol
+++ b/oc/test_files/equals_operation_signed_unsigned.ol
@@ -1,0 +1,22 @@
+/**
+ * Author: Jack Robbins
+ * Verify that a relational operation does indeed have unsigned comparison forced on it
+ */
+
+
+pub fn compare_signed_unsigned(x:i32, y:u32) -> bool{
+	ret x == y;
+}
+
+
+pub fn main() -> i32 {
+	let x:i32 = -5;
+	let y:u32 = 4294967291;
+
+	/**
+	 * Remember that -5 signed is really 42694967291 as an unsigned
+	 * value, so this should be true
+	 */
+	OUNIT: [exit_status = true]
+	ret @compare_signed_unsigned(x, y);
+}

--- a/oc/test_files/relation_operation_unsigned.ol
+++ b/oc/test_files/relation_operation_unsigned.ol
@@ -1,0 +1,22 @@
+/**
+ * Author: Jack Robbins
+ * Verify that a relational operation does indeed have unsigned comparison forced on it
+ */
+
+
+pub fn compare_signed_unsigned(x:i32, y:u32) -> bool{
+	ret x > y;
+}
+
+
+pub fn main() -> i32 {
+	let x:i32 = -5;
+	let y:u32 = 17;
+
+	/**
+	 * Remember that -5 signed is really 42694967291 as an unsigned
+	 * value, so this should be true
+	 */
+	OUNIT: [exit_status = true]
+	ret @compare_signed_unsigned(x, y);
+}

--- a/oc/test_files/short_circuit.ol
+++ b/oc/test_files/short_circuit.ol
@@ -13,7 +13,7 @@ fn really_long_function(arg:mut i32) -> i32 {
 }
 
 pub fn main(arg:i32, argv:char**) -> i32{
-	let x:mut u32 = 232;
+	let x:mut i32 = 232;
 
 	defer {
 		x = x + 3;

--- a/oc/test_files/switch_ollie_enum_arithmetic.ol
+++ b/oc/test_files/switch_ollie_enum_arithmetic.ol
@@ -19,7 +19,7 @@ fn tester(param:my_enum_type) -> i32{
 	let x:mut i32 = 32;
 
 	//Test the type system's ability to deal with this
-	switch(param - 3y){
+	switch(param - 3){
 		case TYPE_ONE -> {
 			x = 32;
 		}
@@ -46,5 +46,7 @@ fn tester(param:my_enum_type) -> i32{
 
 
 pub fn main() -> i32{
-	@tester(TYPE_ONE);
+	//This should hit the default case and actually give us 10
+	OUNIT: [exit_status = 10]
+	ret @tester(TYPE_ONE);
 }


### PR DESCRIPTION
[Type System]: fixes to get_operand_type and rework of type widening. Type widening no longer requires us to have already done the signedness and floating point coercions first.

Closes #1113 
Closes #1114 
Closes #1116 